### PR TITLE
Update jbig2.rst

### DIFF
--- a/docs/jbig2.rst
+++ b/docs/jbig2.rst
@@ -32,6 +32,9 @@ For all other Linux, you must build a JBIG2 encoder from source:
 
 .. _jbig2-lossy:
 
+Dependencies include libtoolize and libleptonica, which on Ubuntu systems 
+are packaged as libtool and libleptonica-dev.
+
 Lossy mode JBIG2
 ================
 


### PR DESCRIPTION
Adding Ubuntu package names for dependencies I needed to save others time. The required package for leptonica is particularly confusing since configure just says "Error! Leptonica not detected." and there are multiple leptonica packages.