### PR TITLE
Add Gentoo Language Installation Instructions

### DIFF
--- a/docs/languages.rst
+++ b/docs/languages.rst
@@ -73,8 +73,8 @@ This enables these languages for all packages (e.g. including aspell).
    # Add global English and German language support (the `l10n_` from equery has to be ommited)
    echo L10N="de en" >> /etc/portage/make.conf
    
-   # (Re-)emerge Tesseract
-   emerge --ask app-text/tesseract
+   # update system to reflect changed USE flags
+   emerge --update --deep --newuse @world
 
 You can then pass the ``-l LANG`` argument to OCRmyPDF to give a hint as
 to what languages it should search for. Multiple languages can be

--- a/docs/languages.rst
+++ b/docs/languages.rst
@@ -54,6 +54,31 @@ to what languages it should search for. Multiple languages can be
 requested using either ``-l eng+fra`` (English and French) or
 ``-l eng -l fra``.
 
+Gentoo users
+============
+
+On Gentoo the package ``app-text/tessdata_fast``, which ``app-text/tesseract`` depends on, installs Tesseract languages.
+``app-text/tessdata_fast`` accepts USE flags to select what languages should be installed, these can be set in ``/etc/portage/package.use``.
+Alternatively one can globally set the `L10N use extension<https://wiki.gentoo.org/wiki/Localization/Guide#L10N>`__ in ``/etc/portage/make.conf`` for all packages.
+
+.. code-block:: bash
+   # Display a list of all Tesseract language packs
+   equery uses app-text/tessdata_fast
+   
+   # Add English and German language support for Tesseract only
+   echo 'app-text/tessdata_fast l10n_de l10n_en' >> /etc/portage/package.use
+   
+   # Add global English and German language support (the `l10n_` from equery has to be ommited)
+   echo L10N="de en" >> /etc/portage/make.conf
+   
+   # (Re-)emerge Tesseract
+   emerge --ask app-text/tesseract
+
+You can then pass the ``-l LANG`` argument to OCRmyPDF to give a hint as
+to what languages it should search for. Multiple languages can be
+requested using either ``-l eng+fra`` (English and French) or
+``-l eng -l fra``.
+
 macOS users
 ===========
 

--- a/docs/languages.rst
+++ b/docs/languages.rst
@@ -70,7 +70,7 @@ This enables these languages for all packages (e.g. including aspell).
    # Add English and German language support for Tesseract only
    echo 'app-text/tessdata_fast l10n_de l10n_en' >> /etc/portage/package.use
    
-   # Add global English and German language support (the `l10n_` from equery has to be ommited)
+   # Add global English and German language support (the `l10n_` from equery has to be omited)
    echo L10N="de en" >> /etc/portage/make.conf
    
    # update system to reflect changed USE flags

--- a/docs/languages.rst
+++ b/docs/languages.rst
@@ -57,11 +57,12 @@ requested using either ``-l eng+fra`` (English and French) or
 Gentoo users
 ============
 
-On Gentoo the package ``app-text/tessdata_fast``, which ``app-text/tesseract`` depends on, installs Tesseract languages.
-``app-text/tessdata_fast`` accepts USE flags to select what languages should be installed, these can be set in ``/etc/portage/package.use``.
-Alternatively one can globally set the `L10N use extension<https://wiki.gentoo.org/wiki/Localization/Guide#L10N>`__ in ``/etc/portage/make.conf`` for all packages.
+On Gentoo the package ``app-text/tessdata_fast``, which ``app-text/tesseract`` depends on, handles Tesseract languages.
+It accepts USE flags to select what languages should be installed, these can be set in ``/etc/portage/package.use``.
+Alternatively one can globally set the `L10N use extension <https://wiki.gentoo.org/wiki/Localization/Guide#L10N>`__ in ``/etc/portage/make.conf`` for all packages (e.g. including aspell).
 
 .. code-block:: bash
+
    # Display a list of all Tesseract language packs
    equery uses app-text/tessdata_fast
    

--- a/docs/languages.rst
+++ b/docs/languages.rst
@@ -59,7 +59,8 @@ Gentoo users
 
 On Gentoo the package ``app-text/tessdata_fast``, which ``app-text/tesseract`` depends on, handles Tesseract languages.
 It accepts USE flags to select what languages should be installed, these can be set in ``/etc/portage/package.use``.
-Alternatively one can globally set the `L10N use extension <https://wiki.gentoo.org/wiki/Localization/Guide#L10N>`__ in ``/etc/portage/make.conf`` for all packages (e.g. including aspell).
+Alternatively one can globally set the `L10N use extension <https://wiki.gentoo.org/wiki/Localization/Guide#L10N>`__ in ``/etc/portage/make.conf``.
+This enables these languages for all packages (e.g. including aspell).
 
 .. code-block:: bash
 


### PR DESCRIPTION
I spent quite some time searching until I asked [a question on the Gentoo Forums](https://forums.gentoo.org/viewtopic.php?p=8696103).

Maybe this PR makes me the last one going through that search.