### PR TITLE
watcher: Add an option to archive processed originals

### DIFF
--- a/docs/batch.rst
+++ b/docs/batch.rst
@@ -124,7 +124,9 @@ Users may need to customize the script to meet their requirements.
 
     "OCR_INPUT_DIRECTORY", "Set input directory to monitor (recursive)"
     "OCR_OUTPUT_DIRECTORY", "Set output directory (should not be under input)"
+    "OCR_ARCHIVE_DIRECTORY", "Set archive directory for processed originals (should not be under input, requires ``OCR_ON_SUCCESS_ARCHIVE`` to be set)"
     "OCR_ON_SUCCESS_DELETE", "This will delete the input file if the exit code is 0 (OK)"
+    "OCR_ON_SUCCESS_ARCHIVE", "This will move the processed orignal file to ``OCR_ARCHIVE_DIRECTORY`` if the exit code is 0 (OK). Note that ``OCR_ON_SUCCESS_DELETE`` takes precedence over this option, i.e. if both options are set, the input file will be deleted."
     "OCR_OUTPUT_DIRECTORY_YEAR_MONTH", "This will place files in the output in ``{output}/{year}/{month}/{filename}``"
     "OCR_DESKEW", "Apply deskew to crooked input PDFs"
     "OCR_JSON_SETTINGS", "A JSON string specifying any other arguments for ``ocrmypdf.ocr``, e.g. ``'OCR_JSON_SETTINGS={""rotate_pages"": true}'``."
@@ -144,16 +146,18 @@ The watcher service is included in the OCRmyPDF Docker image. To run it:
     docker run \
         -v <path to files to convert>:/input \
         -v <path to store results>:/output \
+        -v <path to store processed originals>:/archive \
         -e OCR_OUTPUT_DIRECTORY_YEAR_MONTH=1 \
-        -e OCR_ON_SUCCESS_DELETE=1 \
+        -e OCR_ON_SUCCESS_ARCHIVE=1 \
         -e OCR_DESKEW=1 \
         -e PYTHONUNBUFFERED=1 \
         -it --entrypoint python3 \
         jbarlow83/ocrmypdf \
         watcher.py
 
-This service will watch for a file that matches ``/input/\*.pdf`` and will
-convert it to a OCRed PDF in ``/output/``. The parameters to this image are:
+This service will watch for a file that matches ``/input/\*.pdf``,
+convert it to a OCRed PDF in ``/output/``, and move the processed
+original to ``/archive``. The parameters to this image are:
 
 .. csv-table:: watcher.py parameters for Docker
     :header: "Parameter", "Description"
@@ -161,8 +165,9 @@ convert it to a OCRed PDF in ``/output/``. The parameters to this image are:
 
     "``-v <path to files to convert>:/input``", "Files placed in this location will be OCRed"
     "``-v <path to store results>:/output``", "This is where OCRed files will be stored"
+    "``-v <path to store processed originals>:/archive``", "Archive processed originals here"
     "``-e OCR_OUTPUT_DIRECTORY_YEAR_MONTH=1``", "Define environment variable OCR_OUTPUT_DIRECTORY_YEAR_MONTH=1"
-    "``-e OCR_ON_SUCCESS_DELETE=1``", "Define environment variable"
+    "``-e OCR_ON_SUCCESS_ARCHIVE=1``", "Define environment variable ``OCR_ON_SUCCESS_ARCHIVE`` to move processed originals"
     "``-e OCR_DESKEW=1``", "Define environment variable"
     "``-e PYTHONBUFFERED=1``", "This will force STDOUT to be unbuffered and allow you to see messages in docker logs"
 

--- a/docs/batch.rst
+++ b/docs/batch.rst
@@ -166,10 +166,10 @@ original to ``/archive``. The parameters to this image are:
     "``-v <path to files to convert>:/input``", "Files placed in this location will be OCRed"
     "``-v <path to store results>:/output``", "This is where OCRed files will be stored"
     "``-v <path to store processed originals>:/archive``", "Archive processed originals here"
-    "``-e OCR_OUTPUT_DIRECTORY_YEAR_MONTH=1``", "Define environment variable OCR_OUTPUT_DIRECTORY_YEAR_MONTH=1"
+    "``-e OCR_OUTPUT_DIRECTORY_YEAR_MONTH=1``", "Define environment variable ``OCR_OUTPUT_DIRECTORY_YEAR_MONTH=1`` to place files in the output in ``{output}/{year}/{month}/{filename}``"
     "``-e OCR_ON_SUCCESS_ARCHIVE=1``", "Define environment variable ``OCR_ON_SUCCESS_ARCHIVE`` to move processed originals"
-    "``-e OCR_DESKEW=1``", "Define environment variable"
-    "``-e PYTHONBUFFERED=1``", "This will force STDOUT to be unbuffered and allow you to see messages in docker logs"
+    "``-e OCR_DESKEW=1``", "Define environment variable ``OCR_DESKEW``  to apply deskew to crooked input PDFs"
+    "``-e PYTHONBUFFERED=1``", "This will force ``STDOUT`` to be unbuffered and allow you to see messages in docker logs"
 
 This service relies on polling to check for changes to the filesystem. It
 may not be suitable for some environments, such as filesystems shared on a


### PR DESCRIPTION
This adds a feature from existing OCRmyPDF watchdog Docker containers like [@meyayl/ocrmypdf-batch](https://github.com/meyayl/ocrmypdf-batch) and [@unze/ocrmypdf-watchdog](https://github.com/unze/ocrmypdf-watchdog). With this option, the input directory can be kept clean from already processed files, without losing the originals.