### PR TITLE
Allow pdfminer.six 20220524

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ install_requires =
     coloredlogs>=14.0  # strictly optional
     img2pdf>=0.3.0,<0.5  # pure Python
     packaging>=20
-    pdfminer.six!=20200720,>=20191110,<=20220506
+    pdfminer.six!=20200720,>=20191110,<=20220524
     pikepdf!=5.0.0,>=4.0.0
     pluggy>=0.13.0,<2
     reportlab>=3.5.66


### PR DESCRIPTION
Fixes #970. Fixes #969.

The [changes](https://github.com/pdfminer/pdfminer.six/releases/tag/20220524) in 20220524 are minimal.