### PR TITLE
snap: add --jbig2-lossy support

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -41,6 +41,13 @@ parts:
     stage-packages:
       - lib32stdc++6
 
+  jbig2enc:
+    plugin: autotools
+    source: https://github.com/agl/jbig2enc.git
+    source-tag: '0.29'
+    build-packages:
+      - libleptonica-dev
+
   ocrmypdf:
     plugin: python
     source: https://github.com/ocrmypdf/OCRmyPDF.git


### PR DESCRIPTION
This patch includes a jbig2enc build into the snap package, allow the
user to run OcrMyPDF with the --jbig2-lossy option.

Signed-off-by: 林博仁(Buo-ren Lin) <Buo.Ren.Lin@gmail.com>