### PR TITLE
Incompatible variable type fixed

### DIFF
--- a/src/ocrmypdf/_sync.py
+++ b/src/ocrmypdf/_sync.py
@@ -258,7 +258,7 @@ def exec_concurrent(context: PdfContext, executor: Executor) -> Sequence[str]:
     if max_workers > 1:
         log.info("Start processing %d pages concurrently", max_workers)
 
-    sidecars: list[Path | None] = [None] * len(context.pdfinfo)
+    sidecars: list[Path | None] = [] * len(context.pdfinfo)
     ocrgraft = OcrGrafter(context)
 
     def update_page(result: PageResult, pbar):


### PR DESCRIPTION
Warning from the type checker Pyre

**"filename"**: "src/ocrmypdf/_sync.py"
**"warning_type"**: "Incompatible variable type [9]",
**"warning_message"**: " sidecars is declared to have type `typing.List[typing.Optional[Path]]` but is used as type `typing.List[None]`.",
**"warning_line"**: 261
**"fix"**: [None] to [ ] 