### PR TITLE
add Fedora packages in jbig2 installation documentation

### DIFF
--- a/docs/jbig2.rst
+++ b/docs/jbig2.rst
@@ -37,7 +37,8 @@ For all other Linux, you must build a JBIG2 encoder from source:
 .. _jbig2-lossy:
 
 Dependencies include libtoolize and libleptonica, which on Ubuntu systems
-are packaged as libtool and libleptonica-dev.
+are packaged as libtool and libleptonica-dev. On Fedora (35) they are packaged
+as libtool and leptonica-devel.
 
 Lossy mode JBIG2
 ================


### PR DESCRIPTION
Packages needed to install jbig2 encoding are mentioned for Ubuntu systems but are missing for other systems. This commit adds the infomation in the documentation what the packages are called on Fedora systems: libtool and leptonica-devel.

I tried it out and it works. No further investigation happened to rule out that some package installed on my system might be necessary as well.