### PR TITLE
fix crash on PDF

### DIFF
--- a/src/ocrmypdf/pdfinfo/info.py
+++ b/src/ocrmypdf/pdfinfo/info.py
@@ -525,6 +525,9 @@ def _find_form_xobject_images(pdf: Pdf, container: Object, contentsinfo: Content
     xobjs = resources['/XObject'].as_dict()
     for xobj in xobjs:
         candidate = xobjs[xobj]
+        if candidate is None:
+            continue
+
         if candidate['/Subtype'] != '/Form':
             continue
 


### PR DESCRIPTION
Fixes https://github.com/ocrmypdf/OCRmyPDF/issues/1052 for me.

I don't fully understand what's going on here. My guess is that the PDF has some weird structure and this change makes `pdfinfo` ignore the funkiness instead of crashing.