### PR TITLE
substitute broken link (#1057)

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -293,7 +293,7 @@ Homebrew
 
 .. image:: https://img.shields.io/homebrew/v/ocrmypdf.svg
     :alt: homebrew
-    :target: http://brewformulas.org/Ocrmypdf
+    :target: https://formulae.brew.sh/formula/ocrmypdf
 
 OCRmyPDF is now a standard `Homebrew <https://brew.sh>`__ formula. To
 install on macOS:


### PR DESCRIPTION
Link to [`formulae.brew.sh`](https://formulae.brew.sh/formula/ocrmypdf) as seen in [other repositories](https://github.com/search?type=code&q=/shields.io\/homebrew/+language:reStructuredText) instead of ~[`brewformulas.org`](http://brewformulas.org/Ocrmypdf)~ ([offline since 2020](https://gitlab.com/zedtux/brewformulas.org/issues/223#note_322019672)), to fix #1057.