### PR TITLE
Allow title, subject, author, and keywords to be unset with an empty string argument

### DIFF
--- a/src/ocrmypdf/_pipeline.py
+++ b/src/ocrmypdf/_pipeline.py
@@ -817,6 +817,16 @@ def metadata_fixup(working_file: Path, context: PdfContext) -> Path:
                         del meta['dc:title']
                 missing = set(meta_original.keys()) - set(meta.keys())
                 report_on_metadata(missing)
+                # If the user explicitly specified an empty string for any 
+                # of the following, they should be unset.
+                if options.title == '' and 'dc:title' in meta:
+                    del meta['dc:title']
+                if options.author == '' and 'dc:creator' in meta:
+                    del meta['dc:creator']
+                if options.subject == '' and 'dc:description' in meta:
+                    del meta['dc:description']
+                if options.keywords == '' and 'pdf:Keywords' in meta:
+                    del meta['pdf:Keywords']
 
         optimizing = context.plugin_manager.hook.is_optimization_enabled(
             context=context


### PR DESCRIPTION
Passing --title='', --subject='', author='', or keywords='' is currently ignored. As a workaround, users tend to pass a space when they do not want such original metadata to carry forward. It is more desirable to be able to simply unset the output metadata rather than setting it to " ".