### PR TITLE
Improve PDF rasterisation safety

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -57,6 +57,7 @@ RUN add-apt-repository -y ppa:alex-p/tesseract-ocr-devel
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
   ghostscript \
+  fonts-droid-fallback \
   jbig2dec \
   img2pdf \
   libsm6 libxext6 libxrender-dev \

--- a/src/ocrmypdf/_exec/ghostscript.py
+++ b/src/ocrmypdf/_exec/ghostscript.py
@@ -76,6 +76,7 @@ def rasterize_pdf(
             '-dSAFER',
             '-dBATCH',
             '-dNOPAUSE',
+            '-dPDFSTOPONERROR',
             '-dInterpolateControl=-1',
             f'-sDEVICE={raster_device}',
             f'-dFirstPage={pageno}',


### PR DESCRIPTION
As discussed in https://github.com/ocrmypdf/OCRmyPDF/issues/514 I stumbled across an issue where by a file processed by OCRmyPDF would result in corrupted output (some output pages would be blank where the input was not).

This PR makes a couple of changes to fix this and make the behaviour of OCRmyPDF generally safer:
 - Adds the `fonts-droid-fallback` package to the `Dockerfile` to ensure that GhostScript's fallback font is present
 - Adds the `PDFSTOPONERROR` option to the GhostScript command when rasterising a page of a PDF so that OCRmyPDF fails fast rather than continuing and outputting a bad PDF