### PR TITLE
Fix typos

### DIFF
--- a/docs/batch.rst
+++ b/docs/batch.rst
@@ -133,7 +133,7 @@ Users may need to customize the script to meet their requirements.
     "OCR_OUTPUT_DIRECTORY", "Set output directory (should not be under input)"
     "OCR_ARCHIVE_DIRECTORY", "Set archive directory for processed originals (should not be under input, requires ``OCR_ON_SUCCESS_ARCHIVE`` to be set)"
     "OCR_ON_SUCCESS_DELETE", "This will delete the input file if the exit code is 0 (OK)"
-    "OCR_ON_SUCCESS_ARCHIVE", "This will move the processed orignal file to ``OCR_ARCHIVE_DIRECTORY`` if the exit code is 0 (OK). Note that ``OCR_ON_SUCCESS_DELETE`` takes precedence over this option, i.e. if both options are set, the input file will be deleted."
+    "OCR_ON_SUCCESS_ARCHIVE", "This will move the processed original file to ``OCR_ARCHIVE_DIRECTORY`` if the exit code is 0 (OK). Note that ``OCR_ON_SUCCESS_DELETE`` takes precedence over this option, i.e. if both options are set, the input file will be deleted."
     "OCR_OUTPUT_DIRECTORY_YEAR_MONTH", "This will place files in the output in ``{output}/{year}/{month}/{filename}``"
     "OCR_DESKEW", "Apply deskew to crooked input PDFs"
     "OCR_JSON_SETTINGS", "A JSON string specifying any other arguments for ``ocrmypdf.ocr``, e.g. ``'OCR_JSON_SETTINGS={""rotate_pages"": true}'``."

--- a/docs/cookbook.rst
+++ b/docs/cookbook.rst
@@ -360,7 +360,7 @@ The types of optimization available may expand over time. By default,
 OCRmyPDF compresses data streams inside PDFs, and will change
 inefficient compression modes to more modern versions. A program like
 ``qpdf`` can be used to change encodings, e.g. to inspect the internals
-fo a PDF.
+for a PDF.
 
 .. code-block:: bash
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -530,7 +530,7 @@ programs being installed.
     ``apt install python3-pip python3-venv``, create a virtual environment,
     and install OCRmyPDF in that environment.
 
-    `See here for more inforation on Debian-Python issues
+    `See here for more information on Debian-Python issues
     <https://gist.github.com/tiran/2dec9e03c6f901814f6d1e8dad09528e>`__.
 
 For best results, first install `your platform's

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -193,7 +193,7 @@ Ghostscript also imposes some limitations:
    (Modern Ghostscript can copy JPEG images without transcoding them.)
 -  Ghostscript's PDF/A conversion removes any XMP metadata that is not
    one of the standard XMP metadata namespaces for PDFs. In particular,
-   PRISM Metdata is removed.
+   PRISM Metadata is removed.
 -  Ghostscript's PDF/A conversion seems to remove or deactivate
    hyperlinks and other active content.
 

--- a/docs/languages.rst
+++ b/docs/languages.rst
@@ -74,7 +74,7 @@ This enables these languages for all packages (e.g. including aspell).
    # Add English and German language support for Tesseract only
    echo 'app-text/tessdata_fast l10n_de l10n_en' >> /etc/portage/package.use
    
-   # Add global English and German language support (the `l10n_` from equery has to be omited)
+   # Add global English and German language support (the `l10n_` from equery has to be omitted)
    echo L10N="de en" >> /etc/portage/make.conf
    
    # update system to reflect changed USE flags

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -722,7 +722,7 @@ v10.3.2
 v10.3.1
 =======
 
--  Fixed a number of test suite failures with pdfminer.six older than veresion 20200402.
+-  Fixed a number of test suite failures with pdfminer.six older than version 20200402.
 -  Enabled support for pdfminer.six 20200720.
 
 v10.3.0

--- a/src/ocrmypdf/_exec/tesseract.py
+++ b/src/ocrmypdf/_exec/tesseract.py
@@ -104,7 +104,7 @@ TESSERACT_VERSION_PATTERN = r"""
 
 
 class TesseractVersion(Version):
-    "Modify standard packaging.Version regex to support Tesseract idiosyncracies."
+    "Modify standard packaging.Version regex to support Tesseract idiosyncrasies."
     _regex = re.compile(
         r"^\s*" + TESSERACT_VERSION_PATTERN + r"\s*$", re.VERBOSE | re.IGNORECASE
     )

--- a/src/ocrmypdf/builtin_plugins/tesseract_ocr.py
+++ b/src/ocrmypdf/builtin_plugins/tesseract_ocr.py
@@ -58,7 +58,7 @@ def add_options(parser):
         metavar='METHOD',
         help=(
             "Set Tesseract 5.0+ input image thresholding mode. This may improve OCR "
-            "results on low quality images or those that contain high constrast color. "
+            "results on low quality images or those that contain high contrast color. "
             "legacy-otsu is the Tesseract default; adaptive-otsu is an improved Otsu "
             "algorithm with improved sort for background color changes; sauvola is "
             "based on local standard deviation."

--- a/src/ocrmypdf/pdfa.py
+++ b/src/ocrmypdf/pdfa.py
@@ -84,7 +84,7 @@ def generate_pdfa_ps(target_filename: Path, icc: str = 'sRGB'):
     Ghostscript uses pdfmark for PDF to PDF/A conversion as well. To use Ghostscript
     to create a PDF/A, we need to create a pdfmark file with the necessary metadata.
 
-    This function takes care of the many version-specific bugs and pecularities in
+    This function takes care of the many version-specific bugs and peculiarities in
     Ghostscript's handling of pdfmark.
 
     The only information we put in specifies that we want the file to be a

--- a/src/ocrmypdf/pluginspec.py
+++ b/src/ocrmypdf/pluginspec.py
@@ -269,7 +269,7 @@ def filter_page_image(page: PageContext, image_filename: Path) -> Path:
     to enforce these constraints; it is up to the plugin to do sensible things.
 
     OCRmyPDF will create the PDF page based on the image format used (unless the
-    hook is overriden). If you convert the image to a JPEG, the output page will
+    hook is overridden). If you convert the image to a JPEG, the output page will
     be created as a JPEG, etc. If you change the colorspace, that change will be
     kept. Note that the OCRmyPDF image optimization stage, if enabled, may
     ultimately chose a different format.

--- a/src/ocrmypdf/subprocess/__init__.py
+++ b/src/ocrmypdf/subprocess/__init__.py
@@ -37,7 +37,7 @@ def run(
     """Wrapper around :py:func:`subprocess.run`
 
     The main purpose of this wrapper is to log subprocess output in an orderly
-    fashion that indentifies the responsible subprocess. An additional
+    fashion that identifies the responsible subprocess. An additional
     task is that this function goes to greater lengths to find possible Windows
     locations of our dependencies when they are not on the system PATH.
 


### PR DESCRIPTION
Found via `codespell -S tests,LICENSES -L flate`