### PR TITLE
Fix snap package building (#1082)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2022 Alexander Langanke
 # SPDX-FileCopyrightText: 2022 James R. Barlow
+# SPDX-FileCopyrightText: 2023 林博仁(Buo-ren, Lin) <Buo.Ren.Lin@gmail.com>
 # SPDX-License-Identifier: MPL-2.0
 
 name: ocrmypdf
@@ -56,6 +57,9 @@ parts:
     plugin: python
     source: https://github.com/ocrmypdf/OCRmyPDF.git
 
+    build-packages:
+      - python3-pip
+
     stage-packages:
       - ghostscript
       - icc-profiles-free
@@ -77,7 +81,14 @@ parts:
       - setuptools
       - tqdm
       - pipe
+      - wheel
 
     override-build: |
+      pip3 install --user dephell[full]
+      $HOME/.local/bin/dephell deps convert \
+          --from-path pyproject.toml \
+          --from-format pyproject \
+          --to-path setup.py \
+          --to-format setuppy
       snapcraftctl build
       ln -sf ../usr/lib/libsnapcraft-preload.so $SNAPCRAFT_PART_INSTALL/lib/libsnapcraft-preload.so

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -55,7 +55,7 @@ parts:
 
   ocrmypdf:
     plugin: python
-    source: https://github.com/ocrmypdf/OCRmyPDF.git
+    source: .
 
     build-packages:
       - python3-pip


### PR DESCRIPTION
Currently the snap package no longer contains the main Python package of OCRmyPDF due to the fact that [Snapcraft doesn't run the `pip install .` command when the setup.py isn't detected in the source tree][1].  This patch incorporates a workaround from [Chris Patterson at the Snapcraft Forum][2] to generate a setup.py file from the pyproject.toml to make the package works again.

[1]: [Line 143 of snapcraft/python.py at 0e2cf91 · snapcore/snapcraft · GitHub](https://github.com/snapcore/snapcraft/blob/0e2cf91/snapcraft_legacy/plugins/v2/python.py#L143)
[2]: [Ian Johnson's reply in "Building a core20 python snap using pyproject.toml - snapcraft - snapcraft.io"](https://forum.snapcraft.io/t/building-a-core20-python-snap-using-pyproject-toml/22028/2)

Fixes #1082.