### PR TITLE
Enables creation of a release and uploading the build assets to it

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -255,6 +255,32 @@ jobs:
           password: ${{ secrets.TOKEN_PYPI }}
           # repository_url: https://test.pypi.org/legacy/
 
+  create_release:
+    name: Create GitHub release
+    needs: [wheel_sdist_linux, test_linux, test_macos, test_windows]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
+    permissions:
+      # Required to create a release
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: artifact
+          path: dist
+
+      - name: Create Release
+        id: create-release
+        uses: shogo82148/actions-create-release@v1
+
+      - name: Upload Assets
+        uses: shogo82148/actions-upload-release-asset@v1
+        with:
+          upload_url: ${{ steps.create-release.outputs.upload_url }}
+          asset_path: |
+            ./dist/*.whl
+            ./dist/*.tar.gz
+
   docker:
     name: Build Docker images
     needs: [wheel_sdist_linux, test_linux, test_macos, test_windows]


### PR DESCRIPTION
This PR adds a quick job to create a GitHub release and upload the build wheel and sdist to it.  I opted for a new job rather than adding on tothe pypi upload.  The release doesn't have any content or title, since the release notes are not something that are easily parseable.

An example release looks like this: https://github.com/stumpylog/OCRmyPDF/releases  Github seems to fill in some description, it's not actually set by the action used here.  I think it's either the last commit or tag message.

Fixes #1085 