### PR TITLE
Add installation instructions for Gentoo Linux to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Linux, Windows, macOS and FreeBSD are supported. Docker images are also availabl
 | Windows Subsystem for Linux   | ``apt install ocrmypdf``      |
 | Fedora                        | ``dnf install ocrmypdf``      |
 | macOS (Homebrew)              | ``brew install ocrmypdf``     |
-| macOS (nix)                   | ``nix-env -i  ocrmypdf``      |
+| macOS (nix)                   | ``nix-env -i ocrmypdf``       |
 | LinuxBrew                     | ``brew install ocrmypdf``     |
 | FreeBSD                       | ``pkg install py-ocrmypdf``   |
 | Conda                         | ``conda install ocrmypdf``    |

--- a/README.md
+++ b/README.md
@@ -75,7 +75,6 @@ Linux, Windows, macOS and FreeBSD are supported. Docker images are also availabl
 | FreeBSD                       | ``pkg install py-ocrmypdf``   |
 | Conda                         | ``conda install ocrmypdf``    |
 | Ubuntu Snap                   | ``snap install ocrmypdf``     |
-| Gentoo Linux                  | ``eselect repository enable guru``<br/>``emaint sync --repo guru``<br/>``emerge --ask app-text/OCRmyPDF`` |
 
 For everyone else, [see our documentation](https://ocrmypdf.readthedocs.io/en/latest/installation.html) for installation steps.
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Linux, Windows, macOS and FreeBSD are supported. Docker images are also availabl
 | FreeBSD                       | ``pkg install py-ocrmypdf``   |
 | Conda                         | ``conda install ocrmypdf``    |
 | Ubuntu Snap                   | ``snap install ocrmypdf``     |
+| Gentoo Linux                  | ``eselect repository enable guru``<br/>``emaint sync --repo guru``<br/>``emerge --ask app-text/OCRmyPDF`` |
 
 For everyone else, [see our documentation](https://ocrmypdf.readthedocs.io/en/latest/installation.html) for installation steps.
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -275,6 +275,21 @@ To install OCRmyPDF for Alpine Linux:
 
     apk add ocrmypdf
 
+Gentoo Linux
+------------
+
+.. image:: https://repology.org/badge/version-for-repo/gentoo_ovl_guru/ocrmypdf.svg
+    :alt: Gentoo Linux
+    :target: https://repology.org/metapackage/ocrmypdf
+
+To install OCRmyPDF on Gentoo Linux, use the following commands:
+
+.. code-block:: bash
+
+    eselect repository enable guru
+    emaint sync --repo guru
+    emerge --ask app-text/OCRmyPDF
+
 Other Linux packages
 --------------------
 


### PR DESCRIPTION
As discussed in / closes #1129.

I chose commands most Gentoo users would probably use (there are multiple ways on Gentoo) and also opted not to increase the width of the other table rows to maintain readability of the markdown sources.

I also corrected the table entry for `macOS (nix)` while at it (removed superfluous space character).

Let me know what you think.