### PR TITLE
Handle OSError exceptions in watcher.py

### DIFF
--- a/misc/watcher.py
+++ b/misc/watcher.py
@@ -71,7 +71,7 @@ def wait_for_file_ready(file_path):
     while retries:
         try:
             pdf = pikepdf.open(file_path)
-        except (FileNotFoundError, pikepdf.PdfError) as e:
+        except (FileNotFoundError, OSError, pikepdf.PdfError) as e:
             log.info(f"File {file_path} is not ready yet")
             log.debug("Exception was", exc_info=e)
             time.sleep(POLL_NEW_FILE_SECONDS)


### PR DESCRIPTION
`pikepdf` threw an `OSError` while attempting to open a file that was still being written by a networked scanner. The file in question was on a remote `SMBv3` share. `watcher.py` was launched with `OCR_USE_POLLING=1` and `POLL_NEW_FILE_SECONDS=3` to accommodate this configuration.

This PR seeks to leverage the existing retry logic to recover from this condition.

```
New file: /input/DOC_2023101920314100004_001.pdf. Waiting until fully loaded...
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/usr/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
    self.run()
  File "/usr/local/lib/python3.10/dist-packages/watchdog/observers/api.py", line 204, in run
    self.dispatch_events(self.event_queue)
  File "/usr/local/lib/python3.10/dist-packages/watchdog/observers/api.py", line 380, in dispatch_events
    handler.dispatch(event)
  File "/usr/local/lib/python3.10/dist-packages/watchdog/events.py", line 424, in dispatch
    super().dispatch(event)
  File "/usr/local/lib/python3.10/dist-packages/watchdog/events.py", line 275, in dispatch
    self.on_any_event(event)
  File "/app/watcher.py", line 118, in on_any_event
    execute_ocrmypdf(event.src_path)
  File "/app/watcher.py", line 92, in execute_ocrmypdf
    if not wait_for_file_ready(file_path):
  File "/app/watcher.py", line 73, in wait_for_file_ready
    pdf = pikepdf.open(file_path)
  File "/usr/local/lib/python3.10/dist-packages/pikepdf/_methods.py", line 881, in open
    stream = open(filename_or_stream, 'rb')
OSError: [Errno 16] Device or resource busy: '/input/DOC_2023101920314100004_001.pdf'
```