### PR TITLE
Fix performance advice to match --fast-web-view documentation

### DIFF
--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -17,7 +17,7 @@ If running OCRmyPDF quickly is your main goal, you can use settings such as:
 
 * ``--optimize 0`` to disable file size optimization
 * ``--output-type pdf`` to disable PDF/A generation
-* ``--fast-web-view 0`` to disable fast web view optimization
+* ``--fast-web-view 999999`` to disable fast web view optimization
 * ``--skip-big`` to skip large images, if some pages have large images
 
 You can also avoid:


### PR DESCRIPTION
The current performance advice does not match the documentation of the flag:
> --fast-web-view MEGABYTES
> If the size of file is more than this threshold (in MB), then linearize the PDF for fast web viewing. This allows the PDF to be displayed before it is fully downloaded in web browsers, but increases the space required slightly. By default we skip this for small files which do not benefit. **If the threshold is 0 it will be apply to all files. Set the threshold very high to disable.**