### PR TITLE
allow resolution over ride that might improve text recognition etc

### DIFF
--- a/src/ocrmypdf/_exec/ghostscript.py
+++ b/src/ocrmypdf/_exec/ghostscript.py
@@ -115,7 +115,7 @@ def rasterize_pdf(
             '-dSAFER',
             '-dBATCH',
             '-dNOPAUSE',
-            '-dInterpolateControl=-1',
+         #   '-dInterpolateControl=-1',
             f'-sDEVICE={raster_device}',
             f'-dFirstPage={pageno}',
             f'-dLastPage={pageno}',

--- a/src/ocrmypdf/_pipeline.py
+++ b/src/ocrmypdf/_pipeline.py
@@ -143,8 +143,8 @@ def triage(
         if _pdf_guess_version(input_file):
             if options.image_dpi:
                 log.warning(
-                    "Argument --image-dpi is being ignored because the "
-                    "input file is a PDF, not an image."
+                    "Argument --image-dpi %d is applied to all PDF pages before text recognition.",
+                    options.image_dpi
                 )
             # Origin file is a pdf create a symlink with pdf extension
             safe_symlink(input_file, output_file)
@@ -458,7 +458,11 @@ def calculate_raster_dpi(page_context: PageContext):
     # will not work properly.
     image_dpi = calculate_image_dpi(page_context)
     dpi_profile = page_context.pageinfo.page_dpi_profile()
-    canvas_dpi = get_canvas_square_dpi(page_context, image_dpi)
+    res = page_context.options.image_dpi
+    if res is None:
+        canvas_dpi = get_canvas_square_dpi(page_context, image_dpi)
+    else:
+        canvas_dpi = Resolution(res,res)
     page_dpi = get_page_square_dpi(page_context, image_dpi)
     if dpi_profile and dpi_profile.average_to_max_dpi_ratio < 0.8:
         log.warning(

--- a/src/ocrmypdf/_validation.py
+++ b/src/ocrmypdf/_validation.py
@@ -119,7 +119,10 @@ def check_options_sidecar(options: Namespace) -> None:
                 "--sidecar filename needed when output file is /dev/null or NUL."
             )
         options.sidecar = options.output_file + '.txt'
-    if options.sidecar == options.input_file or options.sidecar == options.output_file:
+    if options.sidecar == '-':
+        options.output_type = "none"
+        log.warning("DRY RUN. Printing text only. No files saved")
+    elif options.sidecar == options.input_file or options.sidecar == options.output_file:
         raise BadArgsError(
             "--sidecar file must be different from the input and output files"
         )
@@ -296,7 +299,7 @@ def create_input_file(options: Namespace, work_folder: Path) -> tuple[Path, str]
 
 
 def check_requested_output_file(options: Namespace) -> None:
-    if options.output_file == '-':
+    if options.output_file == '-' and options.sidecar == None:
         if sys.stdout.isatty():
             raise BadArgsError(
                 "Output was set to stdout '-' but it looks like stdout "


### PR DESCRIPTION



it's struggling with partitioned pictures with varying and unusual resolutions that are occasionally even slightly non square 

even if proper rounding would solve this problem there is no harm in allowing a manual resolution 

the file is SQM261.pdf by Werner Heisenberg if you want to investigate this particular case 

with some luck this will bring up the file

googler -j sqm261.pdf Heisenberg 


# strange interpolation bug. png looks fine but text is garbled anyway 

-dInterpolateControl=-1

disabling interpolation control or whatever this does also produced a massive hickup on one of the tiles ot of the blue

one of the tiles became completely garbled

and another tile lost letters 

but the png has no visible error 

i don't know how to tackle this

disabling since I'm on my phone and can't write gigantic patches that add endless incomprehensible options 

it's probably just wrong and hopefully never necessary and whoever added it forgot all about the reason for it



# horizontal line artifacts from certain fractional resolutions 

it turns out gs bugs out with the calculated dpi -r412.987013x412.987013

black lines over the text destroy random lines of text or remove them completely 

it cannot understand the text when it looks like someone striked out random lines with a pencil 

the scan is saved as many stripes per page 

the edges produce artifacts at particular resolutions 

the best solution would be to output a composite pixel by pixel of the stripes

but it doesn't seem like gs has that capability 

if i set 400 the output is clean and all text is recognised 

most tiles are 408 which also work. 400 or 408 work not the fractional values

so it's either rounding always

or allowing me test my hypothesis with a harmless over ride

since my suspicion eas confirmed i never created a rounding patch which should probably be used also

it's just common sense that a weird fractional (!) resolution might destroy the rendering 

Argument --image-dpi is _pipeline.py:151
being ignored because
the input file is a
PDF, not an image.

the error message is wrong

it should absolutely be possible to over ride

the argument should be passed to ghost script before the OCR stage

strange resolutions can destroy the render apparently 

maybe even if round numbers are used who knows 



# force rounding for resolution 

i did NOT write this patch which should probably exist also

 the automatic resolution is 

dpi=407.959962x412.987013

any of these strange values bug the output when applied to the whole composite page as a square resolution 

it's possible that exactly 408 or 413 would work. did not try a gazillion possibilities its easy to try with the commands below

it's considering both image resolutions and document point size when selecting this

maybe this is all correct except a missing round to nearest integer

i don't think the automatic resolution should be allowed to be fractional 


# clean and over sample has no effect 

 oversample is after ocr and has nothing to do with this 
 
 clean can't remove the lines

they are merged with the letters and impossible to remove 


# work around by changing meta data

if you could post the command to change the pdf meta data to get exactly 400 dpi

pdfinfo in poppler gives

Page size:       612 x 792 pts (letter)

i don't know how that translates to dpi

612/72 is 8 not 8,5 as the output says

if i could reverse the calculation i could possibly change this but it seems to be wrong altogether

the only sensible solution is to allow override

there is no way to get a correct value that always produce correct output 

maybe rounding to whole numbers work better but i doubt there is universal solution more than trial and error



# dry run

i also had to allow a dry run to even test this

 it would not allow me to skip the output file completely 

ocrmypdf 1.pdf --sidecar - - --output-type none
--sidecar file must be    __main__.py:65different from the input
and output files

a better solution would be to promote output to an optional parameter and reduce the command to 

ocrmypdf 1.pdf --sidecar -
dry run. no files written 

or just disable pdf stdout completely and always print plain text to stdout

ocrmypdf 1.pdf -
output is standard printing PLAIN TEXT only

or maybe less confusing a pure option

ocrmypdf 1.pdf --dry-run

but i need to be in front of a computer to do complicated patches with no value for me


# I'm on my phone 

because I am on my phone now i created the simplest patch that solved text recognition for THIS PARTICULAR FILE 

a test bed of files is needed to improve general app quality 

it's too much work to produce a better patch when i don't need it urgently 

someone with a computer can polish it easier than i can

i could write a patch that force whole number resolutions also since the fractional resolution cause significant problems for ghost script in assembling all the pictures 

i also have no signal for several days and can't write the file URL when i am writing this offline in -37 degrees latitude in serene summer atmosphere stability 

there is a massive mast here like a needle into the sky above the trees. should be perfect reception 


my reason for adding text is synthetic voicing. there are no recordings of his personal reflections or even dull droning lectures. i share his worried nature and it's sometimes and awesome burden to bare alone 

in happenstance the document was written offline in complete isolation on a tiny island in the north sea to avoid the continental pollen cloud primarily. and perhaps serene silence of an ocean breeze sea birds and nothing else

i suffer significantly less here compared to Europe despite an abundance of gymnosperms .
i am too restless to confine myself to an island or boat and suffer greatly all through European mid summer 

horses graze in the forest nearby. there are absolutely no wild browsers   their ecosystem management is just far behind.

even dogs roam the forest in the evening but they are not aggressive this far from home 

 no one can understand how few people have the energy to herd the flock. i had to spend a week to circle a massive plantation in lockdown. someone stole their tractor and they legally have blocked all roads and made it a prison. anyone living inside have been given a remote control for the fences. no one is complaining. i saw towns folk push themselves through prickly bushes and struggle to even walk through the fences without any luggage or bicycle. no one is doing anything and it's legal. absolutely incomprehensible where i grow up in the distant north 60 degrees latitude . maybe one thousand people on the planet would have the capacity to prevent this and none of them live here sadly despite the obvious scarcity of mild summer weather in Decembe. it meant several nights outside the forest for me because of the road blocks which is stressful for everyone. the village camping had five dogs that barked constantly. i just sat down next to the road instead where occasional farmers pass by





# OCR with different settings

the last rendering is the only one tesseract can understand properly

the first one has visible lines on it

the second one is a mystery to me since the picture has no visible artifacts where the text is garbled 

i don't have hocr or any other supported renderer in termux and i am offline 

```
pdfinfo SQM261.pdf
Title:           Documento DjVu
Author:          Salvatore
Creator:         PScript5.dll Version 5.2.2
Producer:        GPL Ghostscript 8.63
CreationDate:    Sat Apr 10 18:30:06 2010 -04
ModDate:         Sat Apr 10 18:30:06 2010 -04
Custom Metadata: no
Metadata Stream: yes
Tagged:          no
UserProperties:  no
Suspects:        no
Form:            none
JavaScript:      no
Pages:           16
Encrypted:       no
Page size:       612 x 792 pts (letter)
Page rot:        0
File size:       1217483 bytes
Optimized:       no
PDF version:     1.4


pdfimages SQM261.pdf -list|head
page   num  type   width height color comp bpc  enc interp  object ID x-ppi y-ppi size ratio
--------------------------------------------------------------------------------------------
   1     0 stencil  2853    87  -       1   1  ccitt  no         8  0   408   411  118B 0.4%
   1     1 stencil  2853    87  -       1   1  ccitt  no         9  0   408   408   67B 0.2%
   1     2 stencil  2853    87  -       1   1  ccitt  no        10  0   408   408 1808B 5.8%
   1     3 stencil  2853    87  -       1   1  ccitt  no        11  0   408   408 2696B 8.7%
   1     4 stencil  2853    87  -       1   1  ccitt  no        12  0   408   408  100B 0.3%
   1     5 stencil  2853    87  -       1   1  ccitt  no        13  0   408   408 2702B 8.7%
   1     6 stencil  2853    87  -       1   1  ccitt  no        14  0   408   408 2774B 8.9%
   1     7 stencil  2853    87  -       1   1  ccitt  no        15  0   408   408 2750B 8.9%



cp ~/../usr/lib/python3.11/site-packages/ocrmypdf/pdfinfo/info.py .

python info.py SQM261.pdf|sponge|head|termux-clipboard-set
<PdfInfo('...'), page count=16>
<PageInfo pageno=0 8.5"x11" rotation=0 dpi=407.959962x412.987013 has_text=False>
<ImageInfo '/R10' stencil 2853x87 ? 1 1 Encoding.ccitt 407.959962x407.812500>
<ImageInfo '/R11' stencil 2853x87 ? 1 1 Encoding.ccitt 407.959962x407.812500>
<ImageInfo '/R12' stencil 2853x87 ? 1 1 Encoding.ccitt 407.959962x407.812500>
<ImageInfo '/R13' stencil 2853x87 ? 1 1 Encoding.ccitt 407.959962x407.812500>
<ImageInfo '/R14' stencil 2853x87 ? 1 1 Encoding.ccitt 407.959962x407.812500>
<ImageInfo '/R15' stencil 2853x87 ? 1 1 Encoding.ccitt 407.959962x407.812500>
<ImageInfo '/R16' stencil 2853x87 ? 1 1 Encoding.ccitt 407.959962x407.812500>
<ImageInfo '/R17' stencil 2853x87 ? 1 1 Encoding.ccitt 407.959962x407.812500>



pdfseparate -f 1 -l 1 SQM261.pdf 1.pdf


ocrmypdf 1.pdf ocr.pdf -O 0 --image-dpi 400                      Argument --image-dpi is _pipeline.py:151being ignored because
the input file is a                     PDF, not an image.



ocrmypdf 1.pdf -k ocr.pdf -v 1 -O 0 --output-type pdf 2>&1|termux-clipboard-set

ocrmypdf 14.4.0
Running: ['tesseract', '--version']
Found tesseract 5.3.2
Running: ['tesseract', '--version']
Running: ['gs', '--version']
Found gs 10.01.2
Running: ['gs', '--version']
Running: ['tesseract', '--list-langs']
stdout/stderr = List of available languages in "/data/data/com.termux/files/usr/share/tessdata/" (1):
eng

os.symlink(1.pdf, /data/data/com.termux/files/usr/tmp/ocrmypdf.io.m72rmair/origin)
os.symlink(/data/data/com.termux/files/usr/tmp/ocrmypdf.io.m72rmair/origin, /data/data/com.termux/files/usr/tmp/ocrmypdf.io.m72rmair/origin.pdf)

Using Tesseract OpenMP thread limit 3
    1 Rasterize with png16m, rotation 0
    1 Running: ['gs', '-dQUIET', '-dSAFER', '-dBATCH', '-dNOPAUSE', '-dInterpolateControl=-1', '-sDEVICE=png16m', '-dFirstPage=1', '-dLastPage=1', '-r412.987013x412.987013', '-dPDFSTOPONERROR', '-o', '-', '-sstdout=%stderr', '-dAutoRotatePages=/None', '-f', '/data/data/com.termux/files/usr/tmp/ocrmypdf.io.m72rmair/origin.pdf']
    1 Rotating output by 0
    1 resolution (412.9786, 412.9786)
    1 Running: ['tesseract', '-l', 'eng', '-c', 'textonly_pdf=1', '/data/data/com.termux/files/usr/tmp/ocrmypdf.io.m72rmair/000001_ocr.png', '/data/data/com.termux/files/usr/tmp/ocrmypdf.io.m72rmair/000001_ocr_tess', 'pdf', 'txt']
    1 [tesseract] OMP: Warning #96: Cannot form a team with 4 threads, using 3 instead.
    1 [tesseract] OMP: Hint Consider unsetting KMP_DEVICE_THREAD_LIMIT (KMP_ALL_THREADS), KMP_TEAMS_THREAD_LIMIT, and OMP_THREAD_LIMIT (if any are set).
    1 Text rotation: (text, autorotate, content) -> text misalignment = (0, 0, 0) -> 0
    1 Grafting
    1 Page rotation: (content, auto) -> page = (0, 0) -> 0

Postprocessing...
Running: ['tesseract', '--version']
os.symlink(/data/data/com.termux/files/usr/tmp/ocrmypdf.io.m72rmair/metafix.pdf, /data/data/com.termux/files/usr/tmp/ocrmypdf.io.m72rmair/optimize.pdf)
Image optimization ratio: 1.00 savings: 0.0%
Total file size ratio: 0.95 savings: -4.7%
/data/data/com.termux/files/usr/tmp/ocrmypdf.io.m72rmair/optimize.pdf -> ocr.pdf
Temporary working files retained at:
/data/data/com.termux/files/usr/tmp/ocrmypdf.io.m72rmair



ls $TMPDIR -R|termux-clipboard-set
/data/data/com.termux/files/usr/tmp/ocrmypdf.io.m72rmair/:
000001_ocr.png
000001_ocr_tess.pdf
000001_ocr_tess.txt
000001_rasterize.png
debug.log
graft_layers.pdf
metafix.pdf
optimize.pdf
origin
origin.pdf


gs -sDEVICE=png16m -sOutputFile=1.png -dNOPAUSE -dBATCH -f 1.pdf

file 1.png
1.png: PNG image data, 612 x 792, 8-bit/color RGB, non-interlaced


gs -sDEVICE=png16m -sOutputFile=1.png -dNOPAUSE -dBATCH -r412.987013x412.987013 -dInterpolateControl=-1 -f 1.pdf

file 1.png
1.png: PNG image data, 3510 x 4543, 8-bit/color RGB, non-interlaced

tesseract 1.png -|termux-clipboard-set
Received July 29, 1925 1 2

QUANTUM-THEORETICAL RE-INTERPRETATION
OF KINEMATIC AND MECHANICAL RELATIONS

W. HEISENBERG

are observable.

It is well known that the formal rules which are used in quantum
theory for calculating observable quantities such as the energy of the
hydrogen atom may be seriously criticized on the grounds that they
contain, as basic element, relationships between quantities that are
apparently unobservable in principle, e.g., position and period of
revolution of the electron. Thus these rules lack an evident physical

unobservable quantities may later come within the realm of experi-
mental determination. This hope might be regarded as justified if the
above-mentioned rules were internally consistent and applicable to a
clearly defined range of quantum mechanical problems. Experience
however shows that only the hydrogen atom and its Stark effect are

Fundamental difficulties already arise in the problem of ‘crossed

fields’ (hydrogen atom in electric and magnetic fields of differing

directions). Also, the reaction of atoms to periodically varying fields

cannot be described by these rules. Finally, the extension of the

quantum rules to the treatment of atoms having several electrons has
proved unfeasible.

It has | ] e to ] erize this fail - i}
tum-theoretical rules as a deviation from classical mechanics, since the
rules themselves were essentially derived from classical mechanics.
This characterization has, however, little meaning when one realizes

Editor’s note. This paper was published as Zs. Phys. 33 (1925) 879-893. It was
Signed ‘Goéttingen, Institut fiir theoretische Physik’.

261



gs -sDEVICE=png16m -sOutputFile=1.png -dNOPAUSE -dBATCH -r400x400 -dInterpolateControl=-1 -f 1.pdf

file 1.png
1.png: PNG image data, 3400 x 4400, 8-bit/color RGB, non-interlaced

tesseract 1.png -|termux-clipboard-set
Received July 29, 1925

12

QUANTUM-THEORETICAL RE-INTERPRETATION
OF KINEMATIC AND MECHANICAL RELATIONS

W. HEISENBERG

The present paper seeks to establish a basis for theoretical quantum mechanics
founded exclusively upon relationships between quantities which in principle
are observable.

It is well known that the formal rules which are used in quantum
theory for calculating observable quantities such as the energy of the
hydrogen atom may be seriously criticized on the grounds that they
contain, as basic element, relationships between quantities that are
apparently unobservable in principle, e.g., position and period of
revolution of the electron. Thus these rules lack an evident physical
foundation, unless one still wants to retain the hope that the hitherto
unobservable quantities may later come within the realm of experi-
above-mentioned rules were internally consistent and applicable to a
clearly defined range of quantum mechanical problems. Experience
however shows that only the hydrogen atom and its Stark effect are
amenable to treatment by these formal rules of quantum theory.
Fundamental difficulties already arise in the problem of ‘crossed
fields’ (hydrogen atom in electric and magnetic fields of differing
directions). Also, the reaction of atoms to periodically varying fields
cannot be described by these rules. Finally, the extension of the

Juantum 11€S 1O 1TNne 1reatinci 0 A LOIIlS Na 1L SEVETd C1ECCTIOINS Ild
proved unfeasible.

It has become the practice to characterize this failure of the quan-
tum-theoretical rules as a deviation from classical mechanics, since the
rules themselves were essentially derived from classical mechanics.

This ization h however, little meanin hen one realizes

Editor’s note. This paper was published as Zs. Phys. 33 (1925) 879-893. It was
Signed ‘Gottingen, Institut fiir theoretische Physik’.

261



gs -sDEVICE=png16m -sOutputFile=1.png -dNOPAUSE -dBATCH -r400x400 -f 1.pdf

file 1.png
1.png: PNG image data, 3400 x 4400, 8-bit/color RGB, non-interlaced


tesseract 1.png -|termux-clipboard-set
Received July 29, 1925 1 2

QUANTUM-THEORETICAL RE-INTERPRETATION
OF KINEMATIC AND MECHANICAL RELATIONS

W. HEISENBERG

The present paper seeks to establish a basis for theoretical quantum mechanics
founded exclusively upon relationships between quantities which in principle
are observable.

It is well known that the formal rules which are used in quantum
theory for calculating observable quantities such as the energy of the
hydrogen atom may be seriously criticized on the grounds that they
contain, as basic element, relationships between quantities that are
apparently unobservable in principle, e.g., position and period of
revolution of the electron. Thus these rules lack an evident physical
foundation, unless one still wants to retain the hope that the hitherto
unobservable quantities may later come within the realm of experi-
mental determination. This hope might be regarded as justified if the
above-mentioned rules were internally consistent and applicable to a
clearly defined range of quantum mechanical problems. Experience
however shows that only the hydrogen atom and its Stark effect are
amenable to treatment by these formal rules of quantum theory.
Fundamental difficulties already arise in the problem of ‘crossed
fields’ (hydrogen atom in electric and magnetic fields of differing
directions). Also, the reaction of atoms to periodically varying fields
cannot be described by these rules. Finally, the extension of the
quantum rules to the treatment of atoms having several electrons has
proved unfeasible.

It has become the practice to characterize this failure of the quan-
tum-theoretical rules as a deviation from classical mechanics, since the
rules themselves were essentially derived from classical mechanics.
This characterization has, however, little meaning when one realizes

Editor’s note. This paper was published as Zs. Phys. 33 (1925) 879-893. It was
Signed ‘Géttingen, Institut fiir theoretische Physik’.

261



