### PR TITLE
Handle PermissionError when finding tools

### DIFF
--- a/src/ocrmypdf/subprocess/__init__.py
+++ b/src/ocrmypdf/subprocess/__init__.py
@@ -165,7 +165,7 @@ def get_version(
             env=env,
         )
         output: str = proc.stdout
-    except FileNotFoundError as e:
+    except (FileNotFoundError, PermissionError) as e:
         raise MissingDependencyError(
             f"Could not find program '{program}' on the PATH"
         ) from e


### PR DESCRIPTION
This can happen in case PATH contains directories that are not accessible by the current user, leading to the situation where a missing optional tool (like jbig2) actually breaks processing of files.