### PR TITLE
Fix entrypoint for docker commands

### DIFF
--- a/docs/docker.rst
+++ b/docs/docker.rst
@@ -178,7 +178,7 @@ The OCRmyPDF test suite is installed with image. To run it:
 
 .. code-block:: bash
 
-   docker run --rm --entrypoint python  jbarlow83/ocrmypdf -m pytest
+   docker run --rm --entrypoint python3  jbarlow83/ocrmypdf -m pytest
 
 Accessing the shell
 ===================
@@ -197,7 +197,7 @@ service. The webservice may be launched as follows:
 
 .. code-block:: bash
 
-   docker run --entrypoint python -p 5000:5000  jbarlow83/ocrmypdf webservice.py
+   docker run --entrypoint python3 -p 5000:5000  jbarlow83/ocrmypdf webservice.py
 
 We omit the ``--rm`` parameter so that the container will not be
 automatically deleted when it exits.


### PR DESCRIPTION
Some of the docker commands in the documentation where broken, because they tried to access the python executable as `python`, but it is called `python3`.

This caused this error:
```
docker: Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "python": executable file not found in $PATH: unknown.
```

This pull request replaces all mentions of `--entrypoint python` with `--entrypoint python3`.