### PR TITLE
Update Dockerfile.alpine

### DIFF
--- a/.docker/Dockerfile.alpine
+++ b/.docker/Dockerfile.alpine
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2023 James R. Barlow
 # SPDX-License-Identifier: MPL-2.0
 
-FROM alpine:3.18 as base
+FROM alpine:3.19 as base
 
 ENV LANG=C.UTF-8
 ENV TZ=UTC


### PR DESCRIPTION
Use Alpine 3.19 as base image to ensure we install Ghostscript 10.2.1 to eliminate serious regressions that corrupt PDFs with existing text.

`
Ghostscript 10.0.0 through 10.02.0 (your version: 10.2.0) contain serious regressions that corrupt PDFs with existing text, such as those processed using --skip-text or --redo-ocr. Please upgrade to a newer version, or use --output-type pdf to avoid Ghostscript, or use --force-ocr to discard existing text.
`