### PR TITLE
Add '--needed' flag to arch base-devel install command

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -224,7 +224,7 @@ standard tooling needed to build packages, such as a compiler and binary tools.
 
 .. code-block:: bash
 
-   sudo pacman -S base-devel
+   sudo pacman -S --needed base-devel
 
 Now you are ready to install the OCRmyPDF package.
 


### PR DESCRIPTION
the '--needed' flag only installs the package if it isn't installed, otherwise it would reinstall it if already installed.