### PR TITLE
Fix broken test_rotate_page_level

### DIFF
--- a/tests/test_rotation.py
+++ b/tests/test_rotation.py
@@ -239,7 +239,9 @@ def make_rotate_test(imagefile, outdir, prefix, image_angle, page_angle):
 @pytest.mark.parametrize('image_angle', (0, 90, 180, 270))
 def test_rotate_page_level(image_angle, page_angle, resources, outdir, caplog):
     reference = make_rotate_test(resources / 'typewriter.png', outdir, 'ref', 0, 0)
-    test = make_rotate_test(resources, outdir, 'test', image_angle, page_angle)
+    test = make_rotate_test(
+        resources / 'typewriter.png', outdir, 'test', image_angle, page_angle
+    )
     out = test.with_suffix('.out.pdf')
 
     exitcode = run_ocrmypdf_api(


### PR DESCRIPTION
Before 42ff7fc84289a885c86d4629ebcf8dd9a65cef2d, `make_rotate_test` always used `resources / 'typewriter.png'`, but after the change the second call accidentally used just `resources`, which is a directory, and fails to open.