### PR TITLE
Process ocr_caption lines

### DIFF
--- a/src/ocrmypdf/hocrtransform/_hocr.py
+++ b/src/ocrmypdf/hocrtransform/_hocr.py
@@ -210,7 +210,7 @@ class HocrTransform:
                     for element in par.iterfind(self._child_xpath('span'))
                     if 'class' in element.attrib
                     and element.attrib['class']
-                    in {'ocr_header', 'ocr_line', 'ocr_textfloat'}
+                    in {'ocr_header', 'ocr_line', 'ocr_textfloat', 'ocr_caption'}
                 ):
                     found_lines = True
                     direction = self._get_text_direction(par)


### PR DESCRIPTION
Previously in the hOCR transform, [`ocr_caption`](https://kba.github.io/hocr-spec/1.2/#sec-ocr_caption) spans were ignored. This PR fixes that issue so that OCRmyPDF processes image caption lines instead of ignoring them. As far as I know, `ocr_caption` is the only missing line type that Tesseract can produce, see: https://github.com/tesseract-ocr/tesseract/blob/3157ff0e741ea5c85e16fbd1c6edf20f30eccbd3/src/api/hocrrenderer.cpp#L231-L248