### PR TITLE
doc: Update docker.rst to use full image tag

### DIFF
--- a/docs/docker.rst
+++ b/docs/docker.rst
@@ -115,6 +115,15 @@ Docker volume:
    alias docker_ocrmypdf='docker run --rm  -i --user "$(id -u):$(id -g)" --workdir /data -v "$PWD:/data" ocrmypdf'
    docker_ocrmypdf /data/input.pdf /data/output.pdf
 
+Especially if you use `Podman <https://podman.io/>`__ (or have SELinux enabled on your system), you may need to add ``--userns keep-id`` there, otherwise you may get access errors, because the user is otherwise not mapped to the same UID as on the host:
+
+.. code-block:: bash
+
+   alias podman_ocrmypdf='podman run --rm  -i --user "$(id -u):$(id -g)" --userns keep-id --workdir /data -v "$PWD:/data" ocrmypdf'
+   podman_ocrmypdf /data/input.pdf /data/output.pdf
+
+If you use SELinux you may additionally need to add the ``:Z`` `suffix to the volume <https://docs.podman.io/en/stable/markdown/podman-run.1.html#volume-v-source-volume-host-dir-container-dir-options>`__ or disable SELinux for the container using ``--security-opt label=disable``, which is suggested for system files as they should not be re-labelled. Please refer to the „Note” section at the end of the linked podman documentation for details.
+
 .. _docker-lang-packs:
 
 Adding languages to the Docker image

--- a/docs/docker.rst
+++ b/docs/docker.rst
@@ -87,8 +87,7 @@ To start a Docker container (instance of the image):
 
 .. code-block:: bash
 
-   docker tag jbarlow83/ocrmypdf-alpine ocrmypdf
-   docker run --rm -i ocrmypdf (... all other arguments here...) - -
+   docker run --rm -i jbarlow83/ocrmypdf-alpine (... all other arguments here...) - -
 
 For convenience, create a shell alias to hide the Docker command. It is
 easier to send the input file as stdin and read the output from
@@ -96,7 +95,7 @@ stdout – **this avoids the messy permission issues with Docker entirely**.
 
 .. code-block:: bash
 
-   alias docker_ocrmypdf='docker run --rm -i ocrmypdf'
+   alias docker_ocrmypdf='docker run --rm -i jbarlow83/ocrmypdf-alpine'
    docker_ocrmypdf --version  # runs docker version
    docker_ocrmypdf - - <input.pdf >output.pdf
 
@@ -104,7 +103,7 @@ Or in the wonderful `fish shell <https://fishshell.com/>`__:
 
 .. code-block:: fish
 
-   alias docker_ocrmypdf 'docker run --rm ocrmypdf'
+   alias docker_ocrmypdf 'docker run --rm jbarlow83/ocrmypdf-alpine'
    funcsave docker_ocrmypdf
 
 Alternately, you could mount the local current working directory as a
@@ -112,14 +111,14 @@ Docker volume:
 
 .. code-block:: bash
 
-   alias docker_ocrmypdf='docker run --rm  -i --user "$(id -u):$(id -g)" --workdir /data -v "$PWD:/data" ocrmypdf'
+   alias docker_ocrmypdf='docker run --rm  -i --user "$(id -u):$(id -g)" --workdir /data -v "$PWD:/data" jbarlow83/ocrmypdf-alpine'
    docker_ocrmypdf /data/input.pdf /data/output.pdf
 
 Especially if you use `Podman <https://podman.io/>`__ (or have SELinux enabled on your system), you may need to add ``--userns keep-id`` there, otherwise you may get access errors, because the user is otherwise not mapped to the same UID as on the host:
 
 .. code-block:: bash
 
-   alias podman_ocrmypdf='podman run --rm  -i --user "$(id -u):$(id -g)" --userns keep-id --workdir /data -v "$PWD:/data" ocrmypdf'
+   alias podman_ocrmypdf='podman run --rm  -i --user "$(id -u):$(id -g)" --userns keep-id --workdir /data -v "$PWD:/data" jbarlow83/ocrmypdf-alpine'
    podman_ocrmypdf /data/input.pdf /data/output.pdf
 
 If you use SELinux you may additionally need to add the ``:Z`` `suffix to the volume <https://docs.podman.io/en/stable/markdown/podman-run.1.html#volume-v-source-volume-host-dir-container-dir-options>`__ or disable SELinux for the container using ``--security-opt label=disable``, which is suggested for system files as they should not be re-labelled. Please refer to the „Note” section at the end of the linked podman documentation for details.


### PR DESCRIPTION
Based on https://github.com/ocrmypdf/OCRmyPDF/pull/1488:

I prefer to write the name in full aka `jbarlow83/ocrmypdf-alpine` and I'd also suggest to document this because:
* if you use `docker tag` this AFAIK only tags the currently downloaded (=pulled) version of that image
* in case a new update comes out, the new one will not be pulled automatically and one would have to pull and tag the image locally, again
* This `docker tag`  command is easily overlooked, if users just run `docker run ocrmypdf` this may or may not work, depending on how it is resolved.
   Also, AFAIK if one could get Docker to register https://hub.docker.com/ocrmypdf then this would suddenly be used instead of your image (currently `podman pull docker.io/ocrmypdf` returns a 404 for me, though)
* It is more common to write at least the user namespace there and the project, to prevent such errors.

Also, default [Docker has many shortcuts for this and e.g. assumes Docker-Hub is always being used](https://stackoverflow.com/questions/37861791/how-are-docker-image-names-parsed). Podman usually does not, that's why I personally prefer to use the very full and clear `docker.io/jbarlow83/ocrmypdf-alpine:latest` e.g. for alpine. This makes it not only clear which version is used, but also where it is pulled from (should one have configured different Docker registries).
But I guess this here is a good compromise.