### PR TITLE
fix ._hocr

### DIFF
--- a/src/ocrmypdf/hocrtransform/_hocr.py
+++ b/src/ocrmypdf/hocrtransform/_hocr.py
@@ -263,9 +263,13 @@ class HocrTransform:
 
     def _get_text_direction(self, par):
         """Get the text direction of the paragraph.
-
+    
         Arabic, Hebrew, Persian, are right-to-left languages.
+        When the paragraph element is None, defaults to left-to-right.
         """
+        if par is None:
+            return TextDirection.LTR
+            
         return (
             TextDirection.RTL
             if par.attrib.get('dir', 'ltr') == 'rtl'


### PR DESCRIPTION
## Fix AttributeError in HocrTransform._get_text_direction when par is None

When processing certain HOCR files, the `_get_text_direction` method can receive a `None` value for its `par` parameter. This occurs when either:

1. The HOCR file lacks properly structured paragraph elements (`<p class='ocr_par'>`)
2. The fallback case is triggered but `self.hocr.find(...)` returns `None`

Without a check for this condition, the method attempts to access `par.attrib` on a `None` object, resulting in an `AttributeError`:

```
AttributeError: 'NoneType' object has no attribute 'attrib'
```

## The Fix

This PR adds a simple null check to handle the case where `par` is `None`, returning the default left-to-right text direction instead of crashing.

This change:
- Prevents crashes when processing HOCR files with missing or malformed paragraph structures
- Maintains backward compatibility (same return values and behavior for valid inputs)
- Simplifies error handling for clients of this library
- Follows the principle of defensive programming

## Example File  - error occurring when processing Page 115

[DivXGuide51.pdf](https://github.com/user-attachments/files/19143615/DivXGuide51.pdf)
