### PR TITLE
Fix yaml.docker-compose.security.no-new-privileges.no-new-privileges--tmp-ec39a9d3-d091-4e8f-8a28-4db0bf4bdd45-misc-docker-compose.example.yml

### DIFF
--- a/misc/docker-compose.example.yml
+++ b/misc/docker-compose.example.yml
@@ -4,6 +4,8 @@
 version: "3.3"
 services:
   ocrmypdf:
+    security_opt:
+      - no-new-privileges:true
     restart: always
     container_name: ocrmypdf
     image: jbarlow83/ocrmypdf


### PR DESCRIPTION
This PR fixes yaml.docker-compose.security.no-new-privileges.no-new-privileges--tmp-ec39a9d3-d091-4e8f-8a28-4db0bf4bdd45-misc-docker-compose.example.yml.