### PR TITLE
Fix python.lang.security.audit.eval-detected.eval-detected--tmp-ec39a9d3-d091-4e8f-8a28-4db0bf4bdd45-misc-ocrmypdf_compare.py

### DIFF
--- a/misc/ocrmypdf_compare.py
+++ b/misc/ocrmypdf_compare.py
@@ -1,3 +1,4 @@
+import ast
 # SPDX-FileCopyrightText: 2025 James R. Barlow
 # SPDX-License-Identifier: MIT
 
@@ -78,8 +79,8 @@ def main():
             return
         with st.spinner("Executing..."):
             Path(d, "input.pdf").write_bytes(pdf_bytes)
-            run(args1, env=dict(os.environ, **eval(env1 or "{}")))
-            run(args2, env=dict(os.environ, **eval(env2 or "{}")))
+            run(args1, env=dict(os.environ, **ast.literal_eval(env1 or "{}")))
+            run(args2, env=dict(os.environ, **ast.literal_eval(env2 or "{}")))
 
             col1, col2 = st.columns(2)
             with col1:
@@ -87,7 +88,7 @@ def main():
                     "Ghostscript version A: "
                     + check_output(
                         ["gs", "--version"],
-                        env=dict(os.environ, **eval(env1 or "{}")),
+                        env=dict(os.environ, **ast.literal_eval(env1 or "{}")),
                         text=True,
                     )
                 )
@@ -96,7 +97,7 @@ def main():
                     "Ghostscript version B: "
                     + check_output(
                         ["gs", "--version"],
-                        env=dict(os.environ, **eval(env2 or "{}")),
+                        env=dict(os.environ, **ast.literal_eval(env2 or "{}")),
                         text=True,
                     )
                 )


### PR DESCRIPTION
This PR fixes python.lang.security.audit.eval-detected.eval-detected--tmp-ec39a9d3-d091-4e8f-8a28-4db0bf4bdd45-misc-ocrmypdf_compare.py.