### PR TITLE
Fix the use of the plugin_manager argument

### DIFF
--- a/src/ocrmypdf/api.py
+++ b/src/ocrmypdf/api.py
@@ -357,7 +357,7 @@ def ocr(  # noqa: D417
     create_options_kwargs = {
         k: v
         for k, v in locals().items()
-        if k not in {'input_file', 'output_file', 'kwargs'}
+        if k not in {'input_file', 'output_file', 'kwargs', 'plugin_manager'}
     }
     create_options_kwargs.update(kwargs)
 


### PR DESCRIPTION
### Background
When using the plugin_manager argument in the OCRmyPDF library it throws an error:
`TypeError: plugin_manager: <ocrmypdf._plugin_manager.OcrmypdfPluginManager object at 0xffff8a341fd0> (<class 'ocrmypdf._plugin_manager.OcrmypdfPluginManager'>)`
This error has already been discovered here: https://github.com/ocrmypdf/OCRmyPDF/issues/1379#issuecomment-2295484495

The use of the plugin_manager is necessary to fully replace GhostScript with a plugin.

### Fix
OCRmyPDF tries to add the plugin_manager to the kwargs. However the plugin manager must not be in the kwargs. It is seperately passed into `run_pipeline` at `api.py:380 ` 
If plugin_manager is excluded then it doesn't throw an error anymore.

### Steps to reproduce
Run the following script:
```
import ocrmypdf
from ocrmypdf.api import get_plugin_manager

ocrmypdf.ocr('input.pdf', 'output.pdf', plugin_manager = get_plugin_manager(plugins=[]))
```

Without this change it throws an error.



PS: I put all the relevant info in the PR since a related issue (https://github.com/ocrmypdf/OCRmyPDF/issues/1379) already exists. If you'd like then I can create a new issue 😊