### PR TITLE
Set work_folder in PdfContext options initialization

### DIFF
--- a/src/ocrmypdf/_jobcontext.py
+++ b/src/ocrmypdf/_jobcontext.py
@@ -34,6 +34,7 @@ class PdfContext:
         plugin_manager,
     ):
         self.options = options
+        self.options.work_folder = work_folder
         self.work_folder = work_folder
         self.origin = origin
         self.pdfinfo = pdfinfo


### PR DESCRIPTION
Add `work_folder` attribute to **PdfContext** `options` so it can be accessed in **plugin functions** such as `generate_hocr` via argument options: Namespace. This is to align with the documentation for plugins - https://ocrmypdf.readthedocs.io/en/latest/plugins.html#plugin-requirements