### PR TITLE
feat(ghostscript): add --jpeg-maxdpi and honor --jpeg-quality in PDF/A generation

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -425,8 +425,9 @@ When Ghostscript is used for PDF/A conversion (`--output-type pdfa`,
 `pdfa-1`, `pdfa-2`, or `pdfa-3`), the following options can be used to
 control image recompression behavior:
 
-- `--jpeg-quality Q` sets Ghostscript JPEG quality for recompressed
-    images. `Q=0` uses Ghostscript's default behavior.
+- `--jpeg-quality Q` sets Ghostscript's `-dJPEGQ` for recompressed images.
+  `Q=0` is maximum compression; `Q=100` is best quality. Omitting the flag
+  uses Ghostscript's built-in default.
 - `--jpeg-maxdpi DPI` enables image downsampling and caps color,
     grayscale, and monochrome image resolution to `DPI`.
 

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -419,6 +419,23 @@ curves. In this case, you may want to use a different color conversion
 strategy. The `--color-conversion-strategy` option allows you to select a
 different strategy, such as `RGB`.
 
+## Ghostscript JPEG controls
+
+When Ghostscript is used for PDF/A conversion (`--output-type pdfa`,
+`pdfa-1`, `pdfa-2`, or `pdfa-3`), the following options can be used to
+control image recompression behavior:
+
+- `--jpeg-quality Q` sets Ghostscript JPEG quality for recompressed
+    images. `Q=0` uses Ghostscript's default behavior.
+- `--jpeg-maxdpi DPI` enables image downsampling and caps color,
+    grayscale, and monochrome image resolution to `DPI`.
+
+Example:
+
+```bash
+ocrmypdf --output-type pdfa --jpeg-quality 80 --jpeg-maxdpi 150 in.pdf out.pdf
+```
+
 ## PDF/A output modes
 
 :::{versionchanged} 17.0.0

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -419,16 +419,22 @@ curves. In this case, you may want to use a different color conversion
 strategy. The `--color-conversion-strategy` option allows you to select a
 different strategy, such as `RGB`.
 
-## Ghostscript image downsampling
+## Ghostscript JPEG controls
 
 When Ghostscript is used for PDF/A conversion (`--output-type pdfa`,
-`pdfa-1`, `pdfa-2`, or `pdfa-3`), use `--jpeg-maxdpi DPI` to cap the
-resolution of color, grayscale, and monochrome images in the output.
+`pdfa-1`, `pdfa-2`, or `pdfa-3`), the following options can be used to
+control image recompression behavior:
+
+- `--jpeg-quality Q` sets Ghostscript's `-dJPEGQ` for recompressed images.
+  `Q=0` is maximum compression; `Q=100` is best quality. Omitting the flag
+  uses Ghostscript's built-in default.
+- `--jpeg-maxdpi DPI` enables image downsampling and caps color,
+    grayscale, and monochrome image resolution to `DPI`.
 
 Example:
 
 ```bash
-ocrmypdf --output-type pdfa --jpeg-maxdpi 150 in.pdf out.pdf
+ocrmypdf --output-type pdfa --jpeg-quality 80 --jpeg-maxdpi 150 in.pdf out.pdf
 ```
 
 ## PDF/A output modes

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -419,22 +419,16 @@ curves. In this case, you may want to use a different color conversion
 strategy. The `--color-conversion-strategy` option allows you to select a
 different strategy, such as `RGB`.
 
-## Ghostscript JPEG controls
+## Ghostscript image downsampling
 
 When Ghostscript is used for PDF/A conversion (`--output-type pdfa`,
-`pdfa-1`, `pdfa-2`, or `pdfa-3`), the following options can be used to
-control image recompression behavior:
-
-- `--jpeg-quality Q` sets Ghostscript's `-dJPEGQ` for recompressed images.
-  `Q=0` is maximum compression; `Q=100` is best quality. Omitting the flag
-  uses Ghostscript's built-in default.
-- `--jpeg-maxdpi DPI` enables image downsampling and caps color,
-    grayscale, and monochrome image resolution to `DPI`.
+`pdfa-1`, `pdfa-2`, or `pdfa-3`), use `--jpeg-maxdpi DPI` to cap the
+resolution of color, grayscale, and monochrome images in the output.
 
 Example:
 
 ```bash
-ocrmypdf --output-type pdfa --jpeg-quality 80 --jpeg-maxdpi 150 in.pdf out.pdf
+ocrmypdf --output-type pdfa --jpeg-maxdpi 150 in.pdf out.pdf
 ```
 
 ## PDF/A output modes

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -31,6 +31,18 @@ ocrmypdf --output-type pdf input.pdf output.pdf
 ocrmypdf --output-type pdfa --pdfa-image-compression jpeg input.pdf output.pdf
 ```
 
+### Create a PDF/A with specific JPEG quality
+
+```bash
+ocrmypdf --output-type pdfa --jpeg-quality 80 input.pdf output.pdf
+```
+
+### Create a PDF/A and cap image resolution
+
+```bash
+ocrmypdf --output-type pdfa --jpeg-maxdpi 150 input.pdf output.pdf
+```
+
 ### Modify a file in place
 
 The file will only be overwritten if OCRmyPDF is successful.

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -181,8 +181,8 @@ v17 addresses through alternative codepaths. When Ghostscript is used:
   lossily, based on an internal algorithm. This
   behavior can be suppressed by setting `--pdfa-image-compression` to
   `jpeg` or `lossless` to set all images to one type or the other.
-  You can also tune this behavior with `--jpeg-quality` and force
-  downsampling with `--jpeg-maxdpi` when Ghostscript PDF/A conversion is used.
+  Use `--jpeg-maxdpi` to force downsampling to a maximum DPI when
+  Ghostscript PDF/A conversion is used.
   Ghostscript lacks an option to maintain the input image's format.
   (Modern Ghostscript can copy JPEG images without transcoding them.)
 - Ghostscript's PDF/A conversion removes any XMP metadata that is not

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -181,8 +181,8 @@ v17 addresses through alternative codepaths. When Ghostscript is used:
   lossily, based on an internal algorithm. This
   behavior can be suppressed by setting `--pdfa-image-compression` to
   `jpeg` or `lossless` to set all images to one type or the other.
-  Use `--jpeg-maxdpi` to force downsampling to a maximum DPI when
-  Ghostscript PDF/A conversion is used.
+  You can also tune this behavior with `--jpeg-quality` and force
+  downsampling with `--jpeg-maxdpi` when Ghostscript PDF/A conversion is used.
   Ghostscript lacks an option to maintain the input image's format.
   (Modern Ghostscript can copy JPEG images without transcoding them.)
 - Ghostscript's PDF/A conversion removes any XMP metadata that is not

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -181,6 +181,8 @@ v17 addresses through alternative codepaths. When Ghostscript is used:
   lossily, based on an internal algorithm. This
   behavior can be suppressed by setting `--pdfa-image-compression` to
   `jpeg` or `lossless` to set all images to one type or the other.
+  You can also tune this behavior with `--jpeg-quality` and force
+  downsampling with `--jpeg-maxdpi` when Ghostscript PDF/A conversion is used.
   Ghostscript lacks an option to maintain the input image's format.
   (Modern Ghostscript can copy JPEG images without transcoding them.)
 - Ghostscript's PDF/A conversion removes any XMP metadata that is not

--- a/docs/optimizer.md
+++ b/docs/optimizer.md
@@ -94,11 +94,6 @@ optimize some images by converting them to JPEG, which are lossy. If
 `--output-type pdf` is used, there are no lossy optimizations. Ghostscript's
 JPEG conversion is quite safe.
 
-When Ghostscript PDF/A conversion is used, `--jpeg-quality` also controls
-Ghostscript's JPEG quality setting (`-dJPEGQ`). Omitting the flag uses
-Ghostscript's default. `0` is maximum compression (lowest quality) and
-`100` is best quality and largest output.
-
 Use `--jpeg-maxdpi DPI` to force Ghostscript to downsample color,
 grayscale, and monochrome images to a maximum resolution during PDF/A
 generation.

--- a/docs/optimizer.md
+++ b/docs/optimizer.md
@@ -94,6 +94,14 @@ optimize some images by converting them to JPEG, which are lossy. If
 `--output-type pdf` is used, there are no lossy optimizations. Ghostscript's
 JPEG conversion is quite safe.
 
+When Ghostscript PDF/A conversion is used, `--jpeg-quality` also controls
+Ghostscript's JPEG quality setting. `0` keeps the default, while `1..100`
+selects lower-to-higher quality.
+
+Use `--jpeg-maxdpi DPI` to force Ghostscript to downsample color,
+grayscale, and monochrome images to a maximum resolution during PDF/A
+generation.
+
 If `pngquant` is installed, OCRmyPDF will use it to perform quantize
 paletted images to reduce their size.
 

--- a/docs/optimizer.md
+++ b/docs/optimizer.md
@@ -95,8 +95,9 @@ optimize some images by converting them to JPEG, which are lossy. If
 JPEG conversion is quite safe.
 
 When Ghostscript PDF/A conversion is used, `--jpeg-quality` also controls
-Ghostscript's JPEG quality setting. `0` keeps the default, while `1..100`
-selects lower-to-higher quality.
+Ghostscript's JPEG quality setting (`-dJPEGQ`). Omitting the flag uses
+Ghostscript's default. `0` is maximum compression (lowest quality) and
+`100` is best quality and largest output.
 
 Use `--jpeg-maxdpi DPI` to force Ghostscript to downsample color,
 grayscale, and monochrome images to a maximum resolution during PDF/A

--- a/docs/optimizer.md
+++ b/docs/optimizer.md
@@ -94,6 +94,11 @@ optimize some images by converting them to JPEG, which are lossy. If
 `--output-type pdf` is used, there are no lossy optimizations. Ghostscript's
 JPEG conversion is quite safe.
 
+When Ghostscript PDF/A conversion is used, `--jpeg-quality` also controls
+Ghostscript's JPEG quality setting (`-dJPEGQ`). Omitting the flag uses
+Ghostscript's default. `0` is maximum compression (lowest quality) and
+`100` is best quality and largest output.
+
 Use `--jpeg-maxdpi DPI` to force Ghostscript to downsample color,
 grayscale, and monochrome images to a maximum resolution during PDF/A
 generation.

--- a/src/ocrmypdf/_exec/ghostscript.py
+++ b/src/ocrmypdf/_exec/ghostscript.py
@@ -278,6 +278,7 @@ def generate_pdfa(
     *,
     compression: str,
     color_conversion_strategy: str,
+    jpeg_quality: int | None = None,
     jpeg_maxdpi: int | None = None,
     pdf_version: str = '1.5',
     pdfa_part: str = '2',
@@ -319,6 +320,10 @@ def generate_pdfa(
         # Windows has lots of fatal "permission denied" errors
         stop_on_error = False
 
+    # Use the user-supplied quality if explicitly provided (including 0, which is
+    # maximum Ghostscript compression). Fall back to 95 only when no value given.
+    effective_jpeg_quality = jpeg_quality if jpeg_quality is not None else 95
+
     downsample_args = []
     if jpeg_maxdpi is not None:
         downsample_args = [
@@ -351,7 +356,7 @@ def generate_pdfa(
         + compression_args
         + downsample_args
         + [
-            "-dJPEGQ=95",
+            f"-dJPEGQ={effective_jpeg_quality}",
             "-dSubsetFonts=false",  # Prevents GS from messing up some encodings
             f"-dPDFA={pdfa_part}",
             "-dPDFACompatibilityPolicy=1",

--- a/src/ocrmypdf/_exec/ghostscript.py
+++ b/src/ocrmypdf/_exec/ghostscript.py
@@ -278,7 +278,6 @@ def generate_pdfa(
     *,
     compression: str,
     color_conversion_strategy: str,
-    jpeg_quality: int | None = None,
     jpeg_maxdpi: int | None = None,
     pdf_version: str = '1.5',
     pdfa_part: str = '2',
@@ -320,10 +319,6 @@ def generate_pdfa(
         # Windows has lots of fatal "permission denied" errors
         stop_on_error = False
 
-    # Use the user-supplied quality if explicitly provided (including 0, which is
-    # maximum Ghostscript compression). Fall back to 95 only when no value given.
-    effective_jpeg_quality = jpeg_quality if jpeg_quality is not None else 95
-
     downsample_args = []
     if jpeg_maxdpi is not None:
         downsample_args = [
@@ -356,7 +351,7 @@ def generate_pdfa(
         + compression_args
         + downsample_args
         + [
-            f"-dJPEGQ={effective_jpeg_quality}",
+            "-dJPEGQ=95",
             "-dSubsetFonts=false",  # Prevents GS from messing up some encodings
             f"-dPDFA={pdfa_part}",
             "-dPDFACompatibilityPolicy=1",

--- a/src/ocrmypdf/_exec/ghostscript.py
+++ b/src/ocrmypdf/_exec/ghostscript.py
@@ -320,8 +320,9 @@ def generate_pdfa(
         # Windows has lots of fatal "permission denied" errors
         stop_on_error = False
 
-    # Preserve prior behavior unless user explicitly provides a quality value.
-    effective_jpeg_quality = jpeg_quality if jpeg_quality and jpeg_quality > 0 else 95
+    # Use the user-supplied quality if explicitly provided (including 0, which is
+    # maximum Ghostscript compression). Fall back to 95 only when no value given.
+    effective_jpeg_quality = jpeg_quality if jpeg_quality is not None else 95
 
     downsample_args = []
     if jpeg_maxdpi is not None:

--- a/src/ocrmypdf/_exec/ghostscript.py
+++ b/src/ocrmypdf/_exec/ghostscript.py
@@ -278,6 +278,8 @@ def generate_pdfa(
     *,
     compression: str,
     color_conversion_strategy: str,
+    jpeg_quality: int | None = None,
+    jpeg_maxdpi: int | None = None,
     pdf_version: str = '1.5',
     pdfa_part: str = '2',
     progressbar_class=None,
@@ -318,6 +320,23 @@ def generate_pdfa(
         # Windows has lots of fatal "permission denied" errors
         stop_on_error = False
 
+    # Preserve prior behavior unless user explicitly provides a quality value.
+    effective_jpeg_quality = jpeg_quality if jpeg_quality and jpeg_quality > 0 else 95
+
+    downsample_args = []
+    if jpeg_maxdpi is not None:
+        downsample_args = [
+            "-dDownsampleColorImages=true",
+            "-dColorImageDownsampleThreshold=1.0",
+            "-dDownsampleGrayImages=true",
+            "-dGrayImageDownsampleThreshold=1.0",
+            "-dDownsampleMonoImages=true",
+            "-dMonoImageDownsampleThreshold=1.0",
+            f"-dColorImageResolution={jpeg_maxdpi}",
+            f"-dGrayImageResolution={jpeg_maxdpi}",
+            f"-dMonoImageResolution={jpeg_maxdpi}",
+        ]
+
     # nb no need to specify ProcessColorModel when ColorConversionStrategy
     # is set; see:
     # https://bugs.ghostscript.com/show_bug.cgi?id=699392
@@ -334,8 +353,9 @@ def generate_pdfa(
         ]
         + (['-dPDFSTOPONERROR'] if stop_on_error else [])
         + compression_args
+        + downsample_args
         + [
-            "-dJPEGQ=95",
+            f"-dJPEGQ={effective_jpeg_quality}",
             "-dSubsetFonts=false",  # Prevents GS from messing up some encodings
             f"-dPDFA={pdfa_part}",
             "-dPDFACompatibilityPolicy=1",

--- a/src/ocrmypdf/_options.py
+++ b/src/ocrmypdf/_options.py
@@ -215,6 +215,7 @@ class OcrOptions(BaseModel):
     # Ghostscript options - also accessible via options.ghostscript.<field>
     pdfa_image_compression: str | None = None
     color_conversion_strategy: str = "LeaveColorUnchanged"
+    jpeg_maxdpi: int | None = None
 
     # Optimize/JBIG2 options - also accessible via options.optimize.<field>
     jbig2_threshold: float = 0.85

--- a/src/ocrmypdf/builtin_plugins/ghostscript.py
+++ b/src/ocrmypdf/builtin_plugins/ghostscript.py
@@ -369,6 +369,7 @@ def generate_pdfa(
         output_file=output_file,
         compression=context.options.ghostscript.pdfa_image_compression,
         color_conversion_strategy=context.options.ghostscript.color_conversion_strategy,
+        jpeg_quality=context.options.jpeg_quality,
         jpeg_maxdpi=context.options.ghostscript.jpeg_maxdpi,
         pdf_version=pdf_version,
         pdfa_part=pdfa_part,

--- a/src/ocrmypdf/builtin_plugins/ghostscript.py
+++ b/src/ocrmypdf/builtin_plugins/ghostscript.py
@@ -369,7 +369,6 @@ def generate_pdfa(
         output_file=output_file,
         compression=context.options.ghostscript.pdfa_image_compression,
         color_conversion_strategy=context.options.ghostscript.color_conversion_strategy,
-        jpeg_quality=context.options.jpeg_quality,
         jpeg_maxdpi=context.options.ghostscript.jpeg_maxdpi,
         pdf_version=pdf_version,
         pdfa_part=pdfa_part,

--- a/src/ocrmypdf/builtin_plugins/ghostscript.py
+++ b/src/ocrmypdf/builtin_plugins/ghostscript.py
@@ -54,6 +54,13 @@ class GhostscriptOptions(BaseModel):
     pdfa_image_compression: Annotated[
         PdfaImageCompression, Field(description="PDF/A image compression method")
     ] = PdfaImageCompression.AUTO
+    jpeg_maxdpi: Annotated[
+        int | None,
+        Field(
+            ge=1,
+            description="Maximum DPI for Ghostscript JPEG downsampling during PDF/A generation",
+        ),
+    ] = None
 
     @classmethod
     def add_arguments_to_parser(cls, parser, namespace: str = 'ghostscript'):
@@ -85,6 +92,16 @@ class GhostscriptOptions(BaseModel):
             "are applied to all pages, including those for which OCR was "
             "skipped.  Not supported for --output-type=pdf ; that setting "
             "preserves the original compression of all images.",
+        )
+        gs.add_argument(
+            '--jpeg-maxdpi',
+            type=int,
+            metavar='DPI',
+            default=None,
+            help=(
+                "Downsample color, grayscale, and monochrome images in Ghostscript "
+                "PDF/A output to the specified maximum DPI."
+            ),
         )
 
 
@@ -352,6 +369,8 @@ def generate_pdfa(
         output_file=output_file,
         compression=context.options.ghostscript.pdfa_image_compression,
         color_conversion_strategy=context.options.ghostscript.color_conversion_strategy,
+        jpeg_quality=context.options.jpeg_quality,
+        jpeg_maxdpi=context.options.ghostscript.jpeg_maxdpi,
         pdf_version=pdf_version,
         pdfa_part=pdfa_part,
         progressbar_class=progressbar_class,

--- a/src/ocrmypdf/builtin_plugins/optimize.py
+++ b/src/ocrmypdf/builtin_plugins/optimize.py
@@ -74,23 +74,21 @@ class OptimizeOptions(BaseModel):
         optimizing.add_argument(
             '--jpeg-quality',
             type=numeric(int, 0, 100),
-            default=None,
+            default=0,
             metavar='Q',
-            dest='jpg_quality',
             help=(
-                "Adjust JPEG quality level for JPEG optimization and Ghostscript "
-                "PDF/A generation. "
+                "Adjust JPEG quality level for JPEG optimization. "
                 "100 is best quality and largest output size; "
-                "0 is maximum compression and smallest output; "
-                "omit to use the default quality."
+                "1 is lowest quality and smallest output; "
+                "0 uses the default."
             ),
         )
         optimizing.add_argument(
             '--jpg-quality',
             type=numeric(int, 0, 100),
-            default=None,
+            default=0,
             metavar='Q',
-            dest='jpg_quality',
+            dest='jpeg_quality',
             help=argparse.SUPPRESS,  # Alias for --jpeg-quality
         )
         optimizing.add_argument(

--- a/src/ocrmypdf/builtin_plugins/optimize.py
+++ b/src/ocrmypdf/builtin_plugins/optimize.py
@@ -74,21 +74,23 @@ class OptimizeOptions(BaseModel):
         optimizing.add_argument(
             '--jpeg-quality',
             type=numeric(int, 0, 100),
-            default=0,
+            default=None,
             metavar='Q',
+            dest='jpg_quality',
             help=(
-                "Adjust JPEG quality level for JPEG optimization. "
+                "Adjust JPEG quality level for JPEG optimization and Ghostscript "
+                "PDF/A generation. "
                 "100 is best quality and largest output size; "
-                "1 is lowest quality and smallest output; "
-                "0 uses the default."
+                "0 is maximum compression and smallest output; "
+                "omit to use the default quality."
             ),
         )
         optimizing.add_argument(
             '--jpg-quality',
             type=numeric(int, 0, 100),
-            default=0,
+            default=None,
             metavar='Q',
-            dest='jpeg_quality',
+            dest='jpg_quality',
             help=argparse.SUPPRESS,  # Alias for --jpeg-quality
         )
         optimizing.add_argument(

--- a/src/ocrmypdf/optimize.py
+++ b/src/ocrmypdf/optimize.py
@@ -693,7 +693,7 @@ def optimize(
         safe_symlink(input_file, output_file)
         return output_file
 
-    if not options.jpg_quality:
+    if options.jpg_quality is None:
         options.jpg_quality = DEFAULT_JPEG_QUALITY if options.optimize < 3 else 40
     if not options.png_quality:
         options.png_quality = DEFAULT_PNG_QUALITY if options.optimize < 3 else 30

--- a/src/ocrmypdf/optimize.py
+++ b/src/ocrmypdf/optimize.py
@@ -693,7 +693,7 @@ def optimize(
         safe_symlink(input_file, output_file)
         return output_file
 
-    if options.jpg_quality is None:
+    if not options.jpg_quality:
         options.jpg_quality = DEFAULT_JPEG_QUALITY if options.optimize < 3 else 40
     if not options.png_quality:
         options.png_quality = DEFAULT_PNG_QUALITY if options.optimize < 3 else 30

--- a/tests/test_ghostscript.py
+++ b/tests/test_ghostscript.py
@@ -158,6 +158,31 @@ def test_generate_pdfa_uses_user_jpeg_quality(outdir):
     assert '-dJPEGQ=95' not in args
 
 
+def test_generate_pdfa_jpeg_quality_zero_is_max_compression(outdir):
+    """Explicit jpeg_quality=0 must reach Ghostscript as -dJPEGQ=0 (max compression).
+
+    It must not be silently replaced by the default 95.
+    """
+    with (
+        patch('ocrmypdf._exec.ghostscript.version', return_value=Version('10.05.1')),
+        patch('ocrmypdf._exec.ghostscript.run_polling_stderr') as run_mock,
+    ):
+        run_mock.return_value = subprocess.CompletedProcess(
+            ['gs'], returncode=0, stdout='', stderr=''
+        )
+        ghostscript.generate_pdfa(
+            pdf_pages=[outdir / 'input.pdf'],
+            output_file=outdir / 'out.pdf',
+            compression='jpeg',
+            color_conversion_strategy='RGB',
+            jpeg_quality=0,
+        )
+
+    args = run_mock.call_args.args[0]
+    assert '-dJPEGQ=0' in args
+    assert '-dJPEGQ=95' not in args
+
+
 def test_generate_pdfa_honors_jpeg_maxdpi(outdir):
     with (
         patch('ocrmypdf._exec.ghostscript.version', return_value=Version('10.05.1')),
@@ -171,7 +196,7 @@ def test_generate_pdfa_honors_jpeg_maxdpi(outdir):
             output_file=outdir / 'out.pdf',
             compression='auto',
             color_conversion_strategy='LeaveColorUnchanged',
-            jpeg_quality=0,
+            jpeg_quality=None,
             jpeg_maxdpi=300,
         )
 

--- a/tests/test_ghostscript.py
+++ b/tests/test_ghostscript.py
@@ -137,52 +137,6 @@ def test_rasterize_low_dpi_one_axis(francais, outdir):
         assert im.info['dpi'] == forced_dpi
 
 
-def test_generate_pdfa_uses_user_jpeg_quality(outdir):
-    with (
-        patch('ocrmypdf._exec.ghostscript.version', return_value=Version('10.05.1')),
-        patch('ocrmypdf._exec.ghostscript.run_polling_stderr') as run_mock,
-    ):
-        run_mock.return_value = subprocess.CompletedProcess(
-            ['gs'], returncode=0, stdout='', stderr=''
-        )
-        ghostscript.generate_pdfa(
-            pdf_pages=[outdir / 'input.pdf'],
-            output_file=outdir / 'out.pdf',
-            compression='jpeg',
-            color_conversion_strategy='RGB',
-            jpeg_quality=72,
-        )
-
-    args = run_mock.call_args.args[0]
-    assert '-dJPEGQ=72' in args
-    assert '-dJPEGQ=95' not in args
-
-
-def test_generate_pdfa_jpeg_quality_zero_is_max_compression(outdir):
-    """Explicit jpeg_quality=0 must reach Ghostscript as -dJPEGQ=0 (max compression).
-
-    It must not be silently replaced by the default 95.
-    """
-    with (
-        patch('ocrmypdf._exec.ghostscript.version', return_value=Version('10.05.1')),
-        patch('ocrmypdf._exec.ghostscript.run_polling_stderr') as run_mock,
-    ):
-        run_mock.return_value = subprocess.CompletedProcess(
-            ['gs'], returncode=0, stdout='', stderr=''
-        )
-        ghostscript.generate_pdfa(
-            pdf_pages=[outdir / 'input.pdf'],
-            output_file=outdir / 'out.pdf',
-            compression='jpeg',
-            color_conversion_strategy='RGB',
-            jpeg_quality=0,
-        )
-
-    args = run_mock.call_args.args[0]
-    assert '-dJPEGQ=0' in args
-    assert '-dJPEGQ=95' not in args
-
-
 def test_generate_pdfa_honors_jpeg_maxdpi(outdir):
     with (
         patch('ocrmypdf._exec.ghostscript.version', return_value=Version('10.05.1')),
@@ -196,7 +150,6 @@ def test_generate_pdfa_honors_jpeg_maxdpi(outdir):
             output_file=outdir / 'out.pdf',
             compression='auto',
             color_conversion_strategy='LeaveColorUnchanged',
-            jpeg_quality=None,
             jpeg_maxdpi=300,
         )
 

--- a/tests/test_ghostscript.py
+++ b/tests/test_ghostscript.py
@@ -137,6 +137,52 @@ def test_rasterize_low_dpi_one_axis(francais, outdir):
         assert im.info['dpi'] == forced_dpi
 
 
+def test_generate_pdfa_uses_user_jpeg_quality(outdir):
+    with (
+        patch('ocrmypdf._exec.ghostscript.version', return_value=Version('10.05.1')),
+        patch('ocrmypdf._exec.ghostscript.run_polling_stderr') as run_mock,
+    ):
+        run_mock.return_value = subprocess.CompletedProcess(
+            ['gs'], returncode=0, stdout='', stderr=''
+        )
+        ghostscript.generate_pdfa(
+            pdf_pages=[outdir / 'input.pdf'],
+            output_file=outdir / 'out.pdf',
+            compression='jpeg',
+            color_conversion_strategy='RGB',
+            jpeg_quality=72,
+        )
+
+    args = run_mock.call_args.args[0]
+    assert '-dJPEGQ=72' in args
+    assert '-dJPEGQ=95' not in args
+
+
+def test_generate_pdfa_jpeg_quality_zero_is_max_compression(outdir):
+    """Explicit jpeg_quality=0 must reach Ghostscript as -dJPEGQ=0 (max compression).
+
+    It must not be silently replaced by the default 95.
+    """
+    with (
+        patch('ocrmypdf._exec.ghostscript.version', return_value=Version('10.05.1')),
+        patch('ocrmypdf._exec.ghostscript.run_polling_stderr') as run_mock,
+    ):
+        run_mock.return_value = subprocess.CompletedProcess(
+            ['gs'], returncode=0, stdout='', stderr=''
+        )
+        ghostscript.generate_pdfa(
+            pdf_pages=[outdir / 'input.pdf'],
+            output_file=outdir / 'out.pdf',
+            compression='jpeg',
+            color_conversion_strategy='RGB',
+            jpeg_quality=0,
+        )
+
+    args = run_mock.call_args.args[0]
+    assert '-dJPEGQ=0' in args
+    assert '-dJPEGQ=95' not in args
+
+
 def test_generate_pdfa_honors_jpeg_maxdpi(outdir):
     with (
         patch('ocrmypdf._exec.ghostscript.version', return_value=Version('10.05.1')),
@@ -150,6 +196,7 @@ def test_generate_pdfa_honors_jpeg_maxdpi(outdir):
             output_file=outdir / 'out.pdf',
             compression='auto',
             color_conversion_strategy='LeaveColorUnchanged',
+            jpeg_quality=None,
             jpeg_maxdpi=300,
         )
 

--- a/tests/test_ghostscript.py
+++ b/tests/test_ghostscript.py
@@ -137,6 +137,56 @@ def test_rasterize_low_dpi_one_axis(francais, outdir):
         assert im.info['dpi'] == forced_dpi
 
 
+def test_generate_pdfa_uses_user_jpeg_quality(outdir):
+    with (
+        patch('ocrmypdf._exec.ghostscript.version', return_value=Version('10.05.1')),
+        patch('ocrmypdf._exec.ghostscript.run_polling_stderr') as run_mock,
+    ):
+        run_mock.return_value = subprocess.CompletedProcess(
+            ['gs'], returncode=0, stdout='', stderr=''
+        )
+        ghostscript.generate_pdfa(
+            pdf_pages=[outdir / 'input.pdf'],
+            output_file=outdir / 'out.pdf',
+            compression='jpeg',
+            color_conversion_strategy='RGB',
+            jpeg_quality=72,
+        )
+
+    args = run_mock.call_args.args[0]
+    assert '-dJPEGQ=72' in args
+    assert '-dJPEGQ=95' not in args
+
+
+def test_generate_pdfa_honors_jpeg_maxdpi(outdir):
+    with (
+        patch('ocrmypdf._exec.ghostscript.version', return_value=Version('10.05.1')),
+        patch('ocrmypdf._exec.ghostscript.run_polling_stderr') as run_mock,
+    ):
+        run_mock.return_value = subprocess.CompletedProcess(
+            ['gs'], returncode=0, stdout='', stderr=''
+        )
+        ghostscript.generate_pdfa(
+            pdf_pages=[outdir / 'input.pdf'],
+            output_file=outdir / 'out.pdf',
+            compression='auto',
+            color_conversion_strategy='LeaveColorUnchanged',
+            jpeg_quality=0,
+            jpeg_maxdpi=300,
+        )
+
+    args = run_mock.call_args.args[0]
+    assert '-dJPEGQ=95' in args
+    assert '-dDownsampleColorImages=true' in args
+    assert '-dColorImageDownsampleThreshold=1.0' in args
+    assert '-dDownsampleGrayImages=true' in args
+    assert '-dGrayImageDownsampleThreshold=1.0' in args
+    assert '-dDownsampleMonoImages=true' in args
+    assert '-dMonoImageDownsampleThreshold=1.0' in args
+    assert '-dColorImageResolution=300' in args
+    assert '-dMonoImageResolution=300' in args
+
+
 def test_gs_render_failure(resources, outpdf, caplog):
     exitcode = run_ocrmypdf_api(
         resources / 'blank.pdf',


### PR DESCRIPTION
Hi everyone, I'm a huge fan of ocrmypdf. I was having issues with large (400 pages+) documents with scanned pages, that I couldn't get to a small enough size. I initially had a 2-pass pipeline where I would first use ocrmypdf, then use a custom ghostscript pass with custom compression settings. However, since ocrmypdf uses ghostscript, this can be done in a single pass, if the JPEG image quality can be set by the user, and ocrmypdf exposes a max DPI option that it passes to ghostscript during the compression phase (after the OCR phase).



So this PR exposes two new controls for Ghostscript's JPEG handling during PDF/A generation:
1. **`--jpeg-maxdpi DPI`**: a new option that instructs Ghostscript to downsample all images (color, grayscale and monochrome images) to a maximum resolution during PDF/A output. Threshold for downsampling (meaning, how much higher the dpi has to be to trigger the downsampling) was set to 1.0 instead of the default of 1.5
2. **`--jpeg-quality Q`**:  the ghostscript compression stage had a hard-coded setting of "dJPEGQ=95" because the `--jpeg-quality` setting was used by the PDF optimizer only (in optimize.py) and didn't need to be passed to Ghostscript. Now, Ghostscript does need the actual value for the JPEG Quality, since it will convert images, so that setting is passed to Ghostscript.

#### Rationale
There was no way to cap image DPI when producing a PDF/A via Ghostscript, making it impossible to produce compact, print-ready PDFs from high-resolution scans with a single command.

#### Changes
- `generate_pdfa()` gains two optional keyword arguments: `jpeg_quality` and `jpeg_maxdpi`.
- `-dJPEGQ` is now dynamic: uses the provided quality when it is `0-100`, otherwise falls back to `95` (preserving prior behaviour). Note: `-dJPEGQ=0` is an accepted setting for Ghostscript (maximum compression).
- When `jpeg_maxdpi` is given, the following Ghostscript switches are injected:

  - `-dDownsampleColorImages=true` / `-dColorImageDownsampleThreshold=1.0`
  - `-dDownsampleGrayImages=true` / `-dGrayImageDownsampleThreshold=1.0`
  - `-dDownsampleMonoImages=true` / `-dMonoImageDownsampleThreshold=1.0`
  - `-dColorImageResolution=DPI` / `-dGrayImageResolution=DPI` / `-dMonoImageResolution=DPI`

Added tests, and updated documentation as well.