### PR TITLE
pdfinfo.info: Normalise boxes with reversed coordinates

### DIFF
--- a/src/ocrmypdf/pdfinfo/info.py
+++ b/src/ocrmypdf/pdfinfo/info.py
@@ -130,6 +130,20 @@ class PageInfo:
             pdf, pageno, infile, check_pages, detailed_analysis, miner_state
         )
 
+    def __fix_box(
+        self,
+        box: list[float | Decimal]
+    ) -> list[float | Decimal]:
+        """
+        Normalise boxes where the coordinates are reversed.
+
+        Follows the logic implemented in poppler/MuPDF.
+        """
+        return [min(box[0], box[2]),
+                min(box[1], box[3]),
+                max(box[0], box[2]),
+                max(box[1], box[3])]
+
     def _gather_pageinfo(
         self,
         pdf: Pdf,
@@ -140,15 +154,15 @@ class PageInfo:
         miner_state: PdfMinerState | None,
     ):
         page: Page = pdf.pages[pageno]
-        mediabox = [Decimal(d) for d in page.mediabox.as_list()]
+        mediabox = self.__fix_box([Decimal(d) for d in page.mediabox.as_list()])
         width_pt = mediabox[2] - mediabox[0]
         height_pt = mediabox[3] - mediabox[1]
 
-        self._artbox = [float(d) for d in page.artbox.as_list()]
-        self._bleedbox = [float(d) for d in page.bleedbox.as_list()]
-        self._cropbox = [float(d) for d in page.cropbox.as_list()]
-        self._mediabox = [float(d) for d in page.mediabox.as_list()]
-        self._trimbox = [float(d) for d in page.trimbox.as_list()]
+        self._artbox = self.__fix_box([float(d) for d in page.artbox.as_list()])
+        self._bleedbox = self.__fix_box([float(d) for d in page.bleedbox.as_list()])
+        self._cropbox = self.__fix_box([float(d) for d in page.cropbox.as_list()])
+        self._mediabox = self.__fix_box([float(d) for d in page.mediabox.as_list()])
+        self._trimbox = self.__fix_box([float(d) for d in page.trimbox.as_list()])
 
         check_this_page = pageno in check_pages
 


### PR DESCRIPTION
Sometimes you get weird PDFs where a page has a MediaBox that looks like:

    /MediaBox [ 0 792 612 0 ]

qpdf, and therefore pikepdf, will happily pass this along to you, which eventually leads to a NegativeDimensionError when we pass these coordinates to img2pdf, as seen in #1526.

poppler and MuPDF will normalise these coordinates so that the first pair of x/y coordinates are the lower values, and the second pair are the higher values. Adopt this logic to correct the behaviour.

-----

I'm not 100% sure whether this fix really belongs in ocrmypdf or whether the qpdf people might want to fix it upstream. I haven't added a unit test, if someone wishes to construct one which is appropriately public domain that might be good.