### PR TITLE
Respect explicit color conversion for DeviceN warnings

### DIFF
--- a/src/ocrmypdf/_exec/ghostscript.py
+++ b/src/ocrmypdf/_exec/ghostscript.py
@@ -404,5 +404,7 @@ def generate_pdfa(
             # the **** pattern to split the stderr into parts.
             for part in stderr.split('****'):
                 log.error(part)
-        if _gs_devicen_reported(stderr):
+        if color_conversion_strategy == 'LeaveColorUnchanged' and _gs_devicen_reported(
+            stderr
+        ):
             raise ColorConversionNeededError()

--- a/tests/test_ghostscript.py
+++ b/tests/test_ghostscript.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2022 James R. Barlow
+# SPDX-FileCopyrightText: 2026 Puneet Dixit
 # SPDX-License-Identifier: MPL-2.0
 
 from __future__ import annotations
@@ -234,6 +235,25 @@ def test_generate_pdfa_honors_jpeg_maxdpi(outdir):
     assert '-dColorImageResolution=300' in args
     assert '-dGrayImageResolution=300' in args
     assert '-dMonoImageResolution=300' in args
+
+
+def test_generate_pdfa_allows_user_color_conversion_for_devicen_warning(outdir):
+    with (
+        patch('ocrmypdf._exec.ghostscript.version', return_value=Version('10.05.1')),
+        patch('ocrmypdf._exec.ghostscript.run_polling_stderr') as run_mock,
+    ):
+        run_mock.return_value = subprocess.CompletedProcess(
+            ['gs'],
+            returncode=0,
+            stdout='',
+            stderr='DeviceN color space with inappropriate alternate',
+        )
+        ghostscript.generate_pdfa(
+            pdf_pages=[outdir / 'input.pdf'],
+            output_file=outdir / 'out.pdf',
+            compression='auto',
+            color_conversion_strategy='RGB',
+        )
 
 
 def test_ghostscript_jpeg_options_via_cli(resources, outpdf):


### PR DESCRIPTION
Fixes #1623

## Summary
- only raise `ColorConversionNeededError` for DeviceN alternate warnings when color conversion is left unchanged
- add a mocked `generate_pdfa()` regression test for an explicit conversion strategy

## Tests
- `PATH=/tmp/ocrmypdf-1623-fakebin:$PATH UV_CACHE_DIR=/tmp/ocrmypdf-1623-uv-cache UV_PROJECT_ENVIRONMENT=/tmp/ocrmypdf-1623-venv uv run --group test pytest tests/test_ghostscript.py::test_generate_pdfa_allows_user_color_conversion_for_devicen_warning -q`
- `PATH=/tmp/ocrmypdf-1623-fakebin:$PATH UV_CACHE_DIR=/tmp/ocrmypdf-1623-uv-cache UV_PROJECT_ENVIRONMENT=/tmp/ocrmypdf-1623-venv uv run --group test pytest tests/test_ghostscript.py -k "generate_pdfa" -q`
- `UV_CACHE_DIR=/tmp/ocrmypdf-1623-uv-cache uvx ruff check src/ocrmypdf/_exec/ghostscript.py tests/test_ghostscript.py`
- `UV_CACHE_DIR=/tmp/ocrmypdf-1623-uv-cache uvx ruff format --check src/ocrmypdf/_exec/ghostscript.py tests/test_ghostscript.py`
- `git diff --check`

Note: the temporary `gs` shim only reports a version for test collection on this machine; the regression test mocks the Ghostscript subprocess call.