### PR TITLE
Fix watcher crash on password protected PDFs

### DIFF
--- a/misc/watcher.py
+++ b/misc/watcher.py
@@ -74,6 +74,11 @@ def wait_for_file_ready(
             with pikepdf.Pdf.open(file_path) as pdf:
                 log.debug(f"{file_path} ready with {pdf.pages} pages")
                 return True
+        except pikepdf.PasswordError as e:
+            # Retrying will not produce the password, so give up right away
+            log.error(f"File {file_path} is password protected, skipping")
+            log.debug("Exception was", exc_info=e)
+            return False
         except (FileNotFoundError, OSError) as e:
             log.info(f"File {file_path} is not ready yet")
             log.debug("Exception was", exc_info=e)
@@ -152,7 +157,14 @@ class HandleObserverEvent(PatternMatchingEventHandler):
 
     def on_any_event(self, event):
         if event.event_type in ['created']:
-            execute_ocrmypdf(file_path=Path(event.src_path), **self._settings)
+            try:
+                execute_ocrmypdf(file_path=Path(event.src_path), **self._settings)
+            except Exception:  # noqa: BLE001
+                # An unhandled exception would kill the watchdog observer
+                # thread, leaving the watcher running but blind to new files.
+                log.exception(
+                    f"Error while processing {event.src_path} - watcher will continue"
+                )
 
 
 @app.default

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -8,6 +8,7 @@ import sys
 import time
 from pathlib import Path
 
+import pikepdf
 import pytest
 
 watchdog = pytest.importorskip('watchdog')
@@ -48,6 +49,53 @@ def test_watcher(tmp_path, resources, year_month):
         ).exists()
     else:
         assert (output_dir / 'trivial.pdf').exists()
+
+    proc.terminate()
+    proc.wait()
+
+
+def test_watcher_survives_encrypted_pdf(tmp_path, resources):
+    # A password protected PDF raised an unhandled pikepdf.PasswordError that
+    # killed the watchdog observer thread - the watcher process kept running
+    # but silently ignored all files created afterwards.
+    input_dir = tmp_path / 'input'
+    input_dir.mkdir()
+    output_dir = tmp_path / 'output'
+    output_dir.mkdir()
+    processed_dir = tmp_path / 'processed'
+    processed_dir.mkdir()
+
+    encrypted = tmp_path / 'encrypted.pdf'
+    with pikepdf.open(resources / 'trivial.pdf') as pdf:
+        pdf.save(
+            encrypted,
+            encryption=pikepdf.models.encryption.Encryption(
+                owner='ocrmypdf', user='ocrmypdf', R=6
+            ),
+        )
+
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            Path(__file__).parent.parent / 'misc' / 'watcher.py',
+            str(input_dir),
+            str(output_dir),
+            str(processed_dir),
+        ],
+        cwd=str(tmp_path),
+        env=os.environ.copy(),
+    )
+    time.sleep(5)
+
+    shutil.copy(encrypted, input_dir / 'encrypted.pdf')
+    time.sleep(5)
+
+    # The watcher must still process files arriving after the encrypted one
+    shutil.copy(resources / 'trivial.pdf', input_dir / 'trivial.pdf')
+    time.sleep(5)
+
+    assert (output_dir / 'trivial.pdf').exists()
+    assert not (output_dir / 'encrypted.pdf').exists()
 
     proc.terminate()
     proc.wait()


### PR DESCRIPTION
Fixes #1715

An encrypted PDF dropped into the watched folder raised an unhandled `pikepdf.PasswordError` inside the watchdog event handler: `wait_for_file_ready()` catches `pikepdf.PdfError`, but `PasswordError` derives directly from `Exception`. The exception killed the observer thread, so the watcher process kept running but silently ignored all files created afterwards until restart.

## Changes

- `wait_for_file_ready()`: catch `pikepdf.PasswordError` and give up immediately — retrying cannot produce the password, so there is no point burning the retry budget.
- `on_any_event()`: wrap `execute_ocrmypdf()` in a try/except that logs the full exception. This is the actual safety net: no per-file error (including errors raised by `ocrmypdf.ocr()` itself) can kill the observer thread anymore.
- `tests/test_watcher.py`: regression test that drops an encrypted PDF followed by a normal one and asserts the normal one is still processed. The test fails against the previous watcher (with the `PasswordError` traceback from #1715) and passes with this fix.

If you would rather have the whole process exit on unexpected errors (so that e.g. a Docker restart policy can recover it) instead of logging and continuing, I am happy to adjust.

## Testing

```
$ python -m pytest tests/test_watcher.py
3 passed in 16.79s
```

`ruff check` and `ruff format` are clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)