### PR TITLE
fix: --jpeg-quality/--jpg-quality silently ignored by the CLI

### DIFF
--- a/src/ocrmypdf/cli.py
+++ b/src/ocrmypdf/cli.py
@@ -530,6 +530,13 @@ def namespace_to_options(ns) -> OcrOptions:
     if 'work_folder' in extra_attrs and 'input_file' not in known_fields:
         known_fields['input_file'] = '/dev/null'  # Placeholder
 
+    # 'jpeg_quality' is the argparse dest for --jpeg-quality/--jpg-quality, but the
+    # OcrOptions model field is 'jpg_quality' ('jpeg_quality' is only a compatibility
+    # property, so it's absent from model_fields and would otherwise be dropped into
+    # extra_attrs and silently ignored).
+    if 'jpeg_quality' in extra_attrs and 'jpg_quality' not in known_fields:
+        known_fields['jpg_quality'] = extra_attrs.pop('jpeg_quality')
+
     instance = OcrOptions(**known_fields)
     instance.extra_attrs = extra_attrs
     return instance

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -15,7 +15,7 @@ from ocrmypdf._concurrent import NullProgressBar, SerialExecutor
 from ocrmypdf._exec.tesseract import TesseractVersion
 from ocrmypdf._options import OcrOptions
 from ocrmypdf.api import create_options, setup_plugin_infrastructure
-from ocrmypdf.cli import get_parser
+from ocrmypdf.cli import get_options_and_plugins, get_parser
 from ocrmypdf.exceptions import BadArgsError, MissingDependencyError
 from ocrmypdf.pdfinfo import PdfInfo
 
@@ -92,6 +92,26 @@ def test_mutex_options():
 def test_optimizing(caplog):
     vd.check_options(*make_opts_pm(optimize=0, png_quality=18, jpeg_quality=10))
     assert 'will be ignored because' in caplog.text
+
+
+def test_jpeg_quality_cli_flag_reaches_options():
+    """--jpeg-quality/--jpg-quality must actually reach OcrOptions.jpg_quality.
+
+    Regression test: namespace_to_options() only copied argparse attributes that
+    are literal OcrOptions.model_fields keys. The parsed CLI value lives under
+    'jpeg_quality' (the argparse dest), but the real model field is 'jpg_quality'
+    ('jpeg_quality' is only a compatibility property, absent from model_fields), so
+    the CLI value fell into extra_attrs and was silently dropped. This bug was not
+    caught by test_optimizing above because make_opts_pm()/create_options() build
+    OcrOptions directly from kwargs, never exercising CLI argument parsing.
+    """
+    opts, _pm = get_options_and_plugins(args=['--jpeg-quality', '42', 'a.pdf', 'b.pdf'])
+    assert opts.jpg_quality == 42
+
+    opts2, _pm2 = get_options_and_plugins(
+        args=['--jpg-quality', '17', 'a.pdf', 'b.pdf']
+    )
+    assert opts2.jpg_quality == 17
 
 
 def test_pillow_options():


### PR DESCRIPTION
Fixes #1723

## Summary

`--jpeg-quality`/`--jpg-quality` is silently ignored on the command line: the value never reaches `OcrOptions.jpg_quality`, so the optimizer always falls back to its own hardcoded default quality regardless of what's requested.

## Root cause

`namespace_to_options()` in `cli.py` only copies argparse attributes whose name is a literal key of `OcrOptions.model_fields`:

```python
for key, value in vars(ns).items():
    if key in OcrOptions.model_fields:
        known_fields[key] = value
    ...
    else:
        extra_attrs[key] = value
```

The parsed CLI value lives under `jpeg_quality` (the argparse `dest` for both `--jpeg-quality` and its `--jpg-quality` alias). But the real pydantic field on `OcrOptions` is `jpg_quality`; `jpeg_quality` is only a compatibility `@property` alias (getter/setter forwarding to `jpg_quality`), so it's absent from `model_fields`. The CLI value therefore falls into `extra_attrs` and is dropped — `jpg_quality` stays at its default (`None`), and `optimize.py` (which correctly reads `options.jpg_quality`) always uses its own hardcoded quality (75 under `--optimize` 1/2, 40 under `--optimize` 3).

The direct Python API is unaffected: `ocrmypdf.ocr(jpeg_quality=...)` / `api.create_options()` build `OcrOptions` directly from kwargs, which correctly hits the property setter. Only CLI argument parsing goes through `namespace_to_options()` and hits this drop.

This also explains why the existing `test_optimizing` test (`make_opts_pm(..., jpeg_quality=10)`) didn't catch it — `make_opts_pm`/`create_options` never exercise CLI parsing.

(For context: issue #1138 discusses `--jpeg-quality` confusion, but that's about Ghostscript's separate hardcoded `-dJPEGQ`, not this attribute-name mismatch — unrelated bug, same symptom family.)

## Fix

Explicitly remap `jpeg_quality` → `jpg_quality` in `namespace_to_options()`, mirroring the existing `output_folder`/`work_folder` special-case handling already in that function.

## Test plan

- Added `test_jpeg_quality_cli_flag_reaches_options` in `tests/test_validation.py`, exercising the actual CLI parsing path (`get_options_and_plugins`) for both `--jpeg-quality` and `--jpg-quality`. Confirmed it fails without the fix (`opts.jpg_quality` is `None`, value ends up in `extra_attrs`) and passes with it.
- Full test suite: `760 passed, 72 skipped, 5 xfailed`.
- `ruff format --check .`, `ruff check .`, `mypy src/ocrmypdf` all clean.
- Manually verified end-to-end on a real image: with the fix, `ocrmypdf --jpeg-quality N` produces monotonically-varying output size across N = 10/30/50/70/90/100 (352KB → 1.64MB); without it, output size is identical regardless of N.
