### PR TITLE
fix(strip): remove invisible text inside Form XObjects (#1730)

### DIFF
--- a/src/ocrmypdf/_graft.py
+++ b/src/ocrmypdf/_graft.py
@@ -176,14 +176,52 @@ def _ensure_dictionary(obj: Dictionary | Stream, name: Name):
     return obj[name]
 
 
-def strip_invisible_text(pdf: Pdf, page: Page):
+def _strip_invisible_text_from_form_xobjects(
+    pdf: Pdf,
+    resources: Object,
+    name: Object,
+    inherited_render_mode: int,
+    visited: set[tuple[int, int]],
+) -> None:
+    """Recurse into the Form XObject drawn by ``name Do`` and strip it too."""
+    try:
+        xobj = resources[Name.XObject][cast('Name', name)]
+    except (KeyError, TypeError):
+        return  # dangling or non-dictionary resource; nothing we can strip
+    if xobj.get(Name.Subtype) != Name.Form:
+        return  # image XObjects carry no text operators
+    key = (xobj.objgen[0], xobj.objgen[1])
+    if key in visited or key == (0, 0):
+        # Already handled, or a direct object we cannot identify; a Form
+        # XObject may reference itself transitively, so never revisit one.
+        return
+    visited.add(key)
+    xobj.write(
+        _strip_invisible_text_from_content(
+            pdf,
+            cast('Stream', xobj),
+            xobj.get(Name.Resources, Dictionary()),
+            visited,
+            inherited_render_mode,
+        )
+    )
+
+
+def _strip_invisible_text_from_content(
+    pdf: Pdf,
+    obj: Page | Stream,
+    resources: Object,
+    visited: set[tuple[int, int]],
+    initial_render_mode: int = 0,
+) -> bytes:
+    """Return ``obj``'s content stream with render-mode-3 text objects removed."""
     stream = []
     in_text_obj = False
-    render_mode = 0
+    render_mode = initial_render_mode
     render_mode_stack = []
     text_objects = []
 
-    for instruction in parse_content_stream(page, ''):
+    for instruction in parse_content_stream(obj, ''):
         operands, operator = instruction.operands, instruction.operator
         if operator == Operator('Tr'):
             # operands[0] is already a plain int under pikepdf's default
@@ -198,6 +236,14 @@ def strip_invisible_text(pdf: Pdf, page: Page):
             # IndexError is raised if stack is empty; try to carry on
             with suppress(IndexError):
                 render_mode = render_mode_stack.pop()
+
+        if operator == Operator('Do') and not in_text_obj and operands:
+            # OCRmyPDF grafts its own text layer as a Form XObject, so the
+            # invisible text is not in the page content stream at all. The
+            # current render mode is inherited across the Do.
+            _strip_invisible_text_from_form_xobjects(
+                pdf, resources, operands[0], render_mode, visited
+            )
 
         if not in_text_obj:
             if operator == Operator('BT'):
@@ -215,8 +261,14 @@ def strip_invisible_text(pdf: Pdf, page: Page):
 
     # pikepdf's Collection[...] parameter doesn't structurally match our
     # _ObjectList-based tuples even though it works fine at runtime.
-    content_stream = unparse_content_stream(
+    return unparse_content_stream(
         cast('list[tuple[Collection[Object], Operator]]', stream)
+    )
+
+
+def strip_invisible_text(pdf: Pdf, page: Page):
+    content_stream = _strip_invisible_text_from_content(
+        pdf, page, page.obj.get(Name.Resources, Dictionary()), set()
     )
     page.Contents = Stream(pdf, content_stream)
 

--- a/tests/test_graft.py
+++ b/tests/test_graft.py
@@ -157,3 +157,80 @@ def test_strip_invisble_text():
         'Number of visible text elements did not change'
     )
     assert count('invisible', page) == 0, 'No invisible elems left'
+
+
+def test_strip_invisible_text_in_form_xobject():
+    """Invisible text inside a Form XObject is stripped too.
+
+    Regression test for #1730. OCRmyPDF grafts its own OCR text layer as a
+    Form XObject and appends ``/OCR-xxxx Do`` to the page (see
+    ``OcrGrafter._graft_fpdf2_text_layer``), so on OCRmyPDF's own output the
+    invisible text is not in the page content stream at all and ``--mode
+    strip`` used to be a no-op.
+    """
+    pdf = pikepdf.Pdf.new()
+    page = pdf.add_blank_page()
+    font = pdf.make_indirect(
+        pikepdf.Dictionary(
+            Type=pikepdf.Name.Font,
+            Subtype=pikepdf.Name.Type1,
+            BaseFont=pikepdf.Name.Helvetica,
+        )
+    )
+
+    def text(string, render_mode):
+        return b'BT\n%d Tr\n/F0 12 Tf\n72 720 Td\n(%s) Tj\nET\n' % (
+            render_mode,
+            string,
+        )
+
+    # The grafted text layer: invisible OCR text plus a visible run that must
+    # survive, exactly as they would sit inside an /OCR-... Form XObject.
+    xobj = pdf.make_stream(text(b'invisible', 3) + text(b'visible-in-form', 0))
+    xobj.Type = pikepdf.Name.XObject
+    xobj.Subtype = pikepdf.Name.Form
+    xobj.FormType = 1
+    xobj.BBox = pikepdf.Array([0, 0, 612, 792])
+    xobj.Resources = pikepdf.Dictionary(Font=pikepdf.Dictionary(F0=font))
+    page.obj[pikepdf.Name.Resources] = pikepdf.Dictionary(
+        Font=pikepdf.Dictionary(F0=font),
+        XObject=pikepdf.Dictionary({'/OCR-abc': xobj}),
+    )
+    page.Contents = pikepdf.Stream(pdf, text(b'visible', 0) + b'q\n/OCR-abc Do\nQ\n')
+
+    def strings(obj):
+        return [
+            bytes(operands[0])
+            for operands, operator in pikepdf.parse_content_stream(obj, '')
+            if operator == pikepdf.Operator('Tj')
+        ]
+
+    assert strings(page) == [b'visible']
+    assert strings(xobj) == [b'invisible', b'visible-in-form']
+
+    ocrmypdf._graft.strip_invisible_text(pdf, page)
+
+    assert strings(page) == [b'visible'], 'page text must be untouched'
+    assert strings(xobj) == [b'visible-in-form'], (
+        'invisible text in the Form XObject must be removed, visible text kept'
+    )
+
+
+def test_strip_invisible_text_with_self_referential_form():
+    """A Form XObject that draws itself must not recurse forever (#1730)."""
+    pdf = pikepdf.Pdf.new()
+    page = pdf.add_blank_page()
+    xobj = pdf.make_stream(b'BT\n3 Tr\n/F0 12 Tf\n(invisible) Tj\nET\n/Self Do\n')
+    xobj.Type = pikepdf.Name.XObject
+    xobj.Subtype = pikepdf.Name.Form
+    xobj.FormType = 1
+    xobj.BBox = pikepdf.Array([0, 0, 612, 792])
+    xobj.Resources = pikepdf.Dictionary(XObject=pikepdf.Dictionary({'/Self': xobj}))
+    page.obj[pikepdf.Name.Resources] = pikepdf.Dictionary(
+        XObject=pikepdf.Dictionary({'/Self': xobj})
+    )
+    page.Contents = pikepdf.Stream(pdf, b'/Self Do\n')
+
+    ocrmypdf._graft.strip_invisible_text(pdf, page)
+
+    assert b'invisible' not in xobj.read_bytes()


### PR DESCRIPTION
Fixes #1730.

## The bug

`strip_invisible_text()` calls `parse_content_stream(page, '')`, which walks **only the page's own content stream**. Text drawn through a Form XObject is invisible to it.

That is exactly the shape OCRmyPDF produces. `OcrGrafter._graft_fpdf2_text_layer` (and `_graft_sandwich_text_layer`) wrap the text-only page in a Form XObject named `/OCR-…` and append `q … /OCR-… Do Q` to the page:

```python
xobj = self.pdf_base.make_stream(text_contents)
base_xobjs[text_xobj_name] = xobj
xobj.Subtype = Name.Form
...
pdf_draw_xobj = b'q\n' + (b'%s Do\n' % text_xobj_name) + b'\nQ\n'
base_page.contents_add(new_text_layer, ...)
```

So on a file OCRmyPDF itself produced, the page content stream contains no `BT`/`ET` at all, `strip_invisible_text()` finds nothing to drop, and `--mode strip` rewrites the page unchanged — the reporter's step 3 exactly.

`--mode redo` is affected by the same root cause: it calls `strip_invisible_text()` on the base page right before grafting (`_graft.py`), so re-OCRing an OCRmyPDF output left the old text layer in place and stacked a second one on top of it.

## Why the existing test didn't catch it

`tests/test_strip.py::test_mode_strip_removes_ocr_layer` uses `tests/resources/graph_ocred.pdf`, whose OCR text sits directly in the page content stream:

```
q 0.1 0 0 0.1 0 0 cm
q
10 0 0 10 0 0 cm BT
/R8 8 Tf
...
3 Tr
```

Its only XObject is `/R11`, an `/Image`. That is not the shape the current renderer emits, so the fixture passes while real output fails.

## The fix

Factor the content-stream walk into `_strip_invisible_text_from_content()` and recurse into Form XObjects reached through `Do`:

- the render mode in effect at the `Do` is passed in as the form's initial render mode, since a form inherits the graphics state;
- non-Form XObjects (images) are skipped — they carry no text operators;
- a `visited` set keyed on `objgen` stops a self- or mutually-referential form from recursing forever, and also avoids stripping a shared form twice.

`strip_invisible_text()` keeps its signature and behaviour for the page stream itself.

## Verification

```
$ python -m pytest tests/test_graft.py::test_strip_invisible_text_in_form_xobject \
                   tests/test_graft.py::test_strip_invisible_text_with_self_referential_form \
                   tests/test_graft.py::test_strip_invisble_text
```

| | before this PR | after |
|---|---|---|
| `test_strip_invisble_text` (existing) | pass | pass |
| `test_strip_invisible_text_in_form_xobject` (new) | **fail** | pass |
| `test_strip_invisible_text_with_self_referential_form` (new) | **fail** | pass |

The first new test asserts both directions: the invisible run inside the form is removed *and* a visible run inside the same form survives, as does the page's own visible text.

`ruff check` / `ruff format --check` (0.16.1, the version in `uv.lock`) and `mypy` are clean on both files; `mypy` reported zero errors on `_graft.py` before this change and still does.

I could not run the tesseract-dependent tests in `tests/test_graft.py` (`test_links`, `test_no_glyphless_graft`, `test_redo_ocr_with_offset_mediabox`) locally — no tesseract on this machine — so those rely on CI.

## Note

`docs/contributing.md` asks contributors to add themselves to a file's copyright holders for contributions over 10 lines. I have not done that here, since that is a claim I would rather you make the call on — happy to add the `SPDX-FileCopyrightText` line if you'd like it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
