### PR TITLE
fix(validation): warn that --deskew/--rotate-pages are inert under --ocr-engine none

### DIFF
--- a/src/ocrmypdf/_validation_coordinator.py
+++ b/src/ocrmypdf/_validation_coordinator.py
@@ -134,6 +134,26 @@ class ValidationCoordinator:
                 "--output-type is one of 'pdfa', 'pdfa-1', or 'pdfa-2'"
             )
 
+        # Validate options that depend on OCR engine detection. Skew and
+        # orientation are measured by the OCR engine, and the null engine
+        # measures neither, so these options silently do nothing.
+        if options.ocr_engine == 'none':
+            inert = sorted(
+                name
+                for name, value in {
+                    '--deskew': options.deskew,
+                    '--rotate-pages': options.rotate_pages,
+                }.items()
+                if value
+            )
+            if inert:
+                log.warning(
+                    f"{', '.join(inert)} will have no effect because "
+                    "--ocr-engine none does not detect page skew or "
+                    "orientation. Other image processing options are "
+                    "unaffected."
+                )
+
     def _handle_deprecated_pdf_renderer(self, options: OcrOptions) -> None:
         """Handle deprecated pdf_renderer values by redirecting to fpdf2."""
         if options.pdf_renderer in ('hocr', 'hocrdebug'):

--- a/tests/test_null_ocr_engine.py
+++ b/tests/test_null_ocr_engine.py
@@ -167,3 +167,62 @@ class TestOcrEngineOption:
                 assert 'auto' in action.choices
                 assert action.default == 'auto'
                 break
+
+
+class TestNullOcrEngineInertOptions:
+    """Warn about options the null engine cannot honor.
+
+    Skew and orientation are measured by the OCR engine, and NullOcrEngine
+    measures neither, so --deskew and --rotate-pages are silently inert under
+    --ocr-engine none.
+    """
+
+    @staticmethod
+    def _warnings(caplog, **kwargs) -> list[str]:
+        import logging
+
+        from ocrmypdf._options import OcrOptions
+        from ocrmypdf._validation_coordinator import ValidationCoordinator
+        from ocrmypdf.api import setup_plugin_infrastructure
+
+        setup_plugin_infrastructure()
+        options = OcrOptions(
+            input_file=Path('in.pdf'), output_file=Path('out.pdf'), **kwargs
+        )
+        caplog.clear()
+        with caplog.at_level(
+            logging.WARNING, logger='ocrmypdf._validation_coordinator'
+        ):
+            ValidationCoordinator(MagicMock())._validate_cross_cutting_concerns(options)
+        return [record.getMessage() for record in caplog.records]
+
+    @pytest.mark.parametrize(
+        'kwargs, expected',
+        [
+            ({'deskew': True}, ['--deskew']),
+            ({'rotate_pages': True}, ['--rotate-pages']),
+            ({'deskew': True, 'rotate_pages': True}, ['--deskew', '--rotate-pages']),
+        ],
+    )
+    def test_warns_for_detection_dependent_options(self, caplog, kwargs, expected):
+        """--ocr-engine none should name every inert detection option."""
+        messages = self._warnings(caplog, ocr_engine='none', **kwargs)
+
+        assert len(messages) == 1
+        for option in expected:
+            assert option in messages[0]
+        for option in {'--deskew', '--rotate-pages'} - set(expected):
+            assert option not in messages[0]
+
+    def test_no_warning_without_the_inert_options(self, caplog):
+        """--ocr-engine none on its own is a supported, silent configuration."""
+        assert self._warnings(caplog, ocr_engine='none') == []
+
+    @pytest.mark.parametrize('engine', ['auto', 'tesseract'])
+    def test_no_warning_for_detecting_engines(self, caplog, engine):
+        """Engines that do detect skew/orientation must not be warned about."""
+        messages = self._warnings(
+            caplog, ocr_engine=engine, deskew=True, rotate_pages=True
+        )
+
+        assert messages == []


### PR DESCRIPTION
Refs #1735.

## The problem

`--ocr-engine none` is advertised in the `--ocr-engine` help text as useful for "image processing without text recognition", but two image-processing options stop working under it, silently.

Skew and orientation are measured *by the OCR engine*:

- `preprocess_deskew()` (`_pipeline.py:651`) → `ocr_engine.get_deskew(...)`
- `get_orientation_correction()` (`_pipeline.py:485`) → `ocr_engine.get_orientation(...)`

`NullOcrEngine` returns `0.0` and `OrientationConfidence(angle=0, confidence=0.0)`. So `--deskew` rotates the page by 0°, and `--rotate-pages` computes `correction = 0`, fails the `correction != 0` test, and returns 0. Neither logs anything.

The rest of the chain — `--clean`, `--clean-final`, `--remove-background`, `--oversample`, `--remove-vectors` — does *not* go through the OCR engine and keeps working. That is what makes this confusing rather than obvious: as the reporter of #1735 puts it, the output of `--clean-final` appears to change depending on which OCR engine you picked.

## The change

One warning at validation time, in `_validate_cross_cutting_concerns`. No behavior change on any path.

This is the pattern the file already uses for options that a sibling option neutralizes:

| existing | warns that |
|---|---|
| `_validate_optimize_options` | `--png-quality`/`--jpeg-quality` are ignored under `--optimize=0` |
| `_validate_tesseract_options` | `--tesseract-downsample-above` has no effect without `--tesseract-downsample-large-images` |
| the block directly above this one | `--pdfa-image-compression` only applies to a `pdfa*` output type |

and `check_options_strip()` in `_validation.py` already covers *these exact two options* for `--mode strip` (there as a hard `BadArgsError`, since strip mode rasterizes nothing at all).

Only `--ocr-engine none` is matched: `tesseract_ocr`'s `get_ocr_engine` hook claims both `auto` and `tesseract`, and `null_ocr`'s claims `none` alone, so `auto` never resolves to `NullOcrEngine`.

## Deliberately not in scope

#1735 also floats *"`get_orientation()` and `get_deskew()` from `tesseract.py` should still be run with `--ocr-engine none`"*. I did not do that — it would reintroduce a hard Tesseract dependency for the one engine a user selects specifically to avoid invoking Tesseract, and it would make `--ocr-engine none` behave differently depending on whether Tesseract happens to be installed. That is a design call for a maintainer; this PR only removes the silence.

I also chose `log.warning` over `BadArgsError`. Erroring would match `check_options_strip()` more closely, but it would break existing `--ocr-engine none --deskew` invocations that run fine today (they just don't deskew). Happy to switch it to a hard error if you'd prefer the consistency.

## Tests

Five cases added to `tests/test_null_ocr_engine.py`, unit-level against `ValidationCoordinator` (no Tesseract or Ghostscript needed):

- each of `--deskew` / `--rotate-pages` / both warns, and names only the options actually passed
- `--ocr-engine none` alone stays silent
- `--ocr-engine auto` and `--ocr-engine tesseract` with both options stay silent

Verified red before the fix (3 failures) and green after. `tests/test_null_ocr_engine.py`, `test_ocr_engine_selection.py` and `test_ocr_engine_interface.py` pass in full; `test_input_validation.py` has 10 failures on my machine both with and without this patch (`MissingDependencyError: Could not find program 'tesseract'`). `ruff check` and `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
