### PR TITLE
Handle malformed values in pikepdf_get_int/pikepdf_get_bool

### DIFF
--- a/src/ocrmypdf/helpers.py
+++ b/src/ocrmypdf/helpers.py
@@ -374,9 +374,19 @@ def pikepdf_get_int(obj: pikepdf.Object, key: pikepdf.Name, default: int = 0) ->
     unboxed to a native ``int`` by the time we see it here; under explicit
     conversion mode it would instead be a ``pikepdf.Object``. ``int()``
     handles both, since ``Object`` implements ``__int__``.
+
+    A malformed PDF may store something that is not a number under the key,
+    for which ``int()`` raises. Fall back to *default* in that case, so that
+    callers reading optional hints out of untrusted files do not have to guard
+    every lookup.
     """
     value = obj.get(key)
-    return int(value) if value is not None else default
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
 
 
 def pikepdf_get_bool(
@@ -387,13 +397,23 @@ def pikepdf_get_bool(
     Unlike ``int()``/``float()``, ``bool()`` is not supported on
     ``pikepdf.Object`` (it raises), so both conversion modes must be
     handled explicitly. See :func:`pikepdf_get_int` for background.
+
+    In implicit conversion mode a PDF Boolean arrives as a native ``bool``,
+    and a PDF Integer -- which malformed files use in place of a Boolean --
+    arrives as a native ``int``. Neither has ``.as_bool()``, so only values
+    that are still ``pikepdf.Object`` are routed through it.
     """
     value = obj.get(key)
     if value is None:
         return default
     if isinstance(value, bool):
         return value
-    return value.as_bool(default)
+    if isinstance(value, pikepdf.Object):
+        return value.as_bool(default)
+    try:
+        return bool(value)
+    except (TypeError, ValueError):
+        return default
 
 
 def running_in_docker() -> bool:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -10,11 +10,13 @@ import sys
 from pathlib import Path
 from unittest.mock import MagicMock
 
+import pikepdf
 import pytest
 from packaging.version import Version
 
 from ocrmypdf import helpers
 from ocrmypdf.helpers import running_in_docker
+from ocrmypdf.pdfinfo import PdfInfo
 
 needs_symlink = pytest.mark.skipif(os.name == 'nt', reason='needs posix symlink')
 windows_only = pytest.mark.skipif(os.name != 'nt', reason="Windows test")
@@ -208,3 +210,69 @@ def test_malloc_trim_absent_without_glibc(monkeypatch, uncached_malloc_trim):
 @pytest.mark.skipif(not sys.platform.startswith('linux'), reason="glibc only")
 def test_malloc_trim_found_on_glibc(uncached_malloc_trim):
     assert callable(helpers._malloc_trim())
+
+
+class TestPikepdfGetters:
+    """Cover the untrusted-input paths of pikepdf_get_int/pikepdf_get_bool.
+
+    Both helpers read optional hints out of arbitrary user PDFs, so a value of
+    the wrong PDF type must fall back to the caller's default rather than
+    propagate a Python-level error out of ``PdfInfo``.
+    """
+
+    @pytest.mark.parametrize(
+        'value, expected',
+        [
+            (42, 42),
+            (pikepdf.Object.parse(b'42'), 42),
+            (3.9, 3),  # PDF Real truncates, as int() always has
+            (True, 1),
+            (pikepdf.String('nope'), 7),
+            (pikepdf.Name.Nope, 7),
+            (pikepdf.Array([1, 2]), 7),
+            (None, 7),  # key absent
+        ],
+    )
+    def test_get_int(self, value, expected):
+        d = pikepdf.Dictionary()
+        if value is not None:
+            d[pikepdf.Name.K] = value
+        assert helpers.pikepdf_get_int(d, pikepdf.Name.K, 7) == expected
+
+    @pytest.mark.parametrize(
+        'value, expected',
+        [
+            (True, True),
+            (False, False),
+            (1, True),  # malformed files store Booleans as 0/1
+            (0, False),
+            (pikepdf.Object.parse(b'true'), True),
+            (pikepdf.String('nope'), False),
+            (pikepdf.Name.Nope, False),
+            (pikepdf.Array([1, 2]), False),
+            (None, False),  # key absent
+        ],
+    )
+    def test_get_bool(self, value, expected):
+        d = pikepdf.Dictionary()
+        if value is not None:
+            d[pikepdf.Name.K] = value
+        assert helpers.pikepdf_get_bool(d, pikepdf.Name.K, False) is expected
+
+    def test_integer_marked_does_not_break_pdfinfo(self, outdir):
+        """A /Marked written as an integer must not abort PdfInfo.
+
+        ``pikepdf_get_bool`` only handled a native ``bool``, so an integer
+        raised ``AttributeError: 'int' object has no attribute 'as_bool'``
+        from ``PdfInfo.__init__`` -- before any OCR work began, and naming
+        neither the file nor the field.
+        """
+        pdf = pikepdf.Pdf.new()
+        pdf.add_blank_page(page_size=(200, 200))
+        pdf.Root[pikepdf.Name.MarkInfo] = pdf.make_indirect(
+            pikepdf.Dictionary(Marked=1)
+        )
+        target = outdir / 'marked_int.pdf'
+        pdf.save(target)
+
+        assert PdfInfo(target).is_tagged is True


### PR DESCRIPTION
## What

`pikepdf_get_int` and `pikepdf_get_bool` read optional hints out of arbitrary user PDFs, but neither tolerated a value stored under the wrong PDF type. Each has the mirror image of the other's problem.

### `pikepdf_get_bool` raises on a PDF Integer

It handled a native `bool`, then called `.as_bool()` on everything else:

```python
if isinstance(value, bool):
    return value
return value.as_bool(default)
```

In pikepdf's implicit conversion mode a PDF Integer arrives as a native `int`, which has no `.as_bool()`. Malformed producers routinely store Booleans as `0`/`1`, so `/MarkInfo << /Marked 1 >>` aborts `PdfInfo.__init__`:

```python
import pikepdf
from ocrmypdf.pdfinfo import PdfInfo

pdf = pikepdf.Pdf.new()
pdf.add_blank_page(page_size=(200, 200))
pdf.Root[pikepdf.Name.MarkInfo] = pdf.make_indirect(pikepdf.Dictionary(Marked=1))
pdf.save('marked_int.pdf')

PdfInfo('marked_int.pdf')
```

```
AttributeError: 'int' object has no attribute 'as_bool'
  File "src/ocrmypdf/pdfinfo/info.py", line 469, in __init__
  File "src/ocrmypdf/helpers.py", line 396, in pikepdf_get_bool
```

This happens before any OCR work begins, and the error names neither the file nor the field. `info.py:457` reads `/NeedsRendering` the same way.

### `pikepdf_get_int` raises on a non-numeric value

```python
return int(value) if value is not None else default
```

`int()` raises `TypeError: Object is not an integer` on a String, Name or Array, so a wrong-typed `/Width`, `/Height`, `/Predictor`, `/Colors` or `/BitsPerComponent` propagates out of `optimize.py` (lines 268, 286-288, 654-655) and `pdfinfo/_image.py` (lines 95-96, 104-105) — even though the caller already supplied a default for the missing-key case.

Observed on this branch, `default=7` / `default=False`:

| value under the key | `pikepdf_get_int` | `pikepdf_get_bool` |
| --- | --- | --- |
| Integer `42` | `42` | **`AttributeError`** |
| Real `3.9` | `3` | **`AttributeError`** |
| String / Name / Array | **`TypeError`** | `False` |
| Boolean | `1` | `True` |
| key absent | `7` | `False` |

## Why this way

Both now fall back to `default` on a value they cannot convert, which is the behaviour the `default` argument already implies and the one pikepdf's own `Object.as_bool(default)` provides for this exact situation.

For `pikepdf_get_bool` the fix is to route only values that are still `pikepdf.Object` through `.as_bool()` — that method exists precisely to coerce an arbitrary `Object` with a fallback — and coerce native scalars directly. That keeps `.as_bool()` doing the work it was chosen for in the original code rather than replacing it with a hand-rolled type ladder.

I kept the truncating behaviour of `int()` on a PDF Real (`3.9 -> 3`) rather than rounding, since that is the existing behaviour and callers compare against pixel dimensions.

These wrappers were introduced in `212b28e` ("Fix mypy pikepdf Object typing errors in pdfinfo/optimize/graft") to satisfy the type checker, which is consistent with the malformed-input paths never having been exercised. `mypy src/ocrmypdf/helpers.py` still reports `Success: no issues found`, so the change does not regress what they were added for.

## Tests

Added `TestPikepdfGetters` to `tests/test_helpers.py`: every PDF type against both helpers, plus the `PdfInfo` path for the integer `/Marked` case above.

Reverting both fixes turns exactly six red, while the twelve well-formed-value cases stay green:

```
FAILED tests/test_helpers.py::TestPikepdfGetters::test_get_int[value4-7]
FAILED tests/test_helpers.py::TestPikepdfGetters::test_get_int[value5-7]
FAILED tests/test_helpers.py::TestPikepdfGetters::test_get_int[value6-7]
FAILED tests/test_helpers.py::TestPikepdfGetters::test_get_bool[1-True]
FAILED tests/test_helpers.py::TestPikepdfGetters::test_get_bool[0-False]
FAILED tests/test_helpers.py::TestPikepdfGetters::test_integer_marked_does_not_break_pdfinfo
6 failed, 25 passed, 5 skipped
```

With the change in place, on Python 3.12 / macOS with `pikepdf` from `--group test`:

```
tests/test_helpers.py                                   31 passed, 5 skipped
test_helpers + test_pdfinfo + test_optimize
  + test_check_pdf                                      87 passed, 5 skipped, 18 errors
ruff check / ruff format --check                        clean
mypy src/ocrmypdf/helpers.py                            Success: no issues found
```

The 18 errors are all `MissingDependencyError` collection errors in `test_optimize.py` for external binaries this machine does not have; I confirmed via `git stash` that they are identical on a clean checkout. The 5 skips are Windows- and glibc-only tests.

AI assistance was used for this change; I reviewed every changed line and ran the commands above locally.
